### PR TITLE
Use v3 GNQL stats endpoint

### DIFF
--- a/enterprise-api-v3.md
+++ b/enterprise-api-v3.md
@@ -1059,7 +1059,7 @@ Request:
 
 ```bash
 curl --request GET \
-     --url 'https://api.greynoise.io/v2/experimental/gnql/stats?query=classification%3A%20malicious&count=5' \
+     --url 'https://api.greynoise.io/v3/gnql/stats?query=classification%3A%20malicious&count=5' \
      --header 'accept: application/json' \
      --header 'key: GREYNOISE_API_KEY'
 ```

--- a/src/tools/gnql-stats.test.ts
+++ b/src/tools/gnql-stats.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "fs";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import { describe, expect, it } from "@jest/globals";
+
+describe("gnql-stats tool", () => {
+  it("uses the v3 stats endpoint", () => {
+    const sourcePath = resolve(dirname(fileURLToPath(import.meta.url)), "gnql-stats.ts");
+    const source = readFileSync(sourcePath, "utf8");
+
+    expect(source).toContain("`v3/gnql/stats`");
+    expect(source).not.toContain("v2/experimental/gnql/stats");
+  });
+});

--- a/src/tools/gnql-stats.ts
+++ b/src/tools/gnql-stats.ts
@@ -97,15 +97,12 @@ Examples:
           }
         })();
 
-        // Encode the GNQL query for URL
-        const encodedQuery = encodeURIComponent(query);
-
         // Get statistics for the query
         const statsData = await fetchGreyNoise<GnqlStatsResponse>(
-          `v2/experimental/gnql/stats?query=${encodedQuery}&count=${count}`,
+          `v3/gnql/stats`,
           apiBase,
           apiKey,
-          {},
+          { query, count },
         );
 
         // Format a readable response

--- a/src/types/greynoise-response.ts
+++ b/src/types/greynoise-response.ts
@@ -156,6 +156,8 @@ export interface GnqlStatsResponse {
   count: number;
   /** The original GNQL query string */
   query: string;
+  /** The executed query if the original query was adjusted due to plan limitations */
+  adjusted_query?: string;
   /** Statistical breakdowns of the query results */
   stats: {
     /** Breakdown by classification */
@@ -219,7 +221,7 @@ export interface GnqlStatsResponse {
     /** Breakdown by operating system */
     operating_systems?: Array<{
       /** Operating system name */
-      os: string;
+      operating_system: string;
       /** Number of IPs running this OS */
       count: number;
     }> | null;

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "@jest/globals";
+import type { GnqlStatsResponse } from "../types/greynoise-response.js";
+import { formatGnqlStats } from "./formatters.js";
+
+describe("formatGnqlStats", () => {
+  it("formats v3 adjusted query and operating system fields", () => {
+    const data: GnqlStatsResponse = {
+      count: 42,
+      query: "classification:malicious",
+      adjusted_query: "(classification:malicious) last_seen:90d",
+      stats: {
+        classifications: [{ classification: "malicious", count: 42 }],
+        organizations: [],
+        countries: [],
+        tags: [],
+        actors: [],
+        operating_systems: [{ operating_system: "Linux", count: 10 }],
+      },
+    };
+
+    const output = formatGnqlStats(data);
+
+    expect(output).toContain("Adjusted Query: `(classification:malicious) last_seen:90d`");
+    expect(output).toContain("- **Linux**: 10 IPs");
+  });
+});

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -24,6 +24,9 @@ import {
 export function formatGnqlStats(data: GnqlStatsResponse): string {
   let response = `# GNQL Stats Results\n\n`;
   response += `Query: \`${data.query}\`\n\n`;
+  if (data.adjusted_query) {
+    response += `Adjusted Query: \`${data.adjusted_query}\`\n\n`;
+  }
   response += `Found ${data.count.toLocaleString()} matching IPs.\n\n`;
 
   // Add classification breakdown
@@ -102,7 +105,7 @@ export function formatGnqlStats(data: GnqlStatsResponse): string {
   if (data.stats.operating_systems && data.stats.operating_systems.length > 0) {
     response += `## Operating Systems\n\n`;
     for (const item of data.stats.operating_systems) {
-      response += `- **${item.os}**: ${item.count.toLocaleString()} IPs\n`;
+      response += `- **${item.operating_system}**: ${item.count.toLocaleString()} IPs\n`;
     }
     response += `\n`;
   }

--- a/test-tools.js
+++ b/test-tools.js
@@ -12,19 +12,62 @@
  *                If not provided, tests all tools.
  */
 
-import { getGreyNoiseApiKey, getGreyNoiseApiBase } from "./build/utils/api-key.js";
-import { fetchGreyNoise, postToGreyNoise } from "./build/utils/fetch.js";
+import fetch from "node-fetch";
 
 // Get API credentials
-const GREYNOISE_API_BASE = getGreyNoiseApiBase();
-let GREYNOISE_API_KEY;
+const GREYNOISE_API_BASE = "https://api.greynoise.io/";
+const GREYNOISE_API_KEY = process.env.GREYNOISE_API_KEY || "";
 
-try {
-  GREYNOISE_API_KEY = getGreyNoiseApiKey();
-} catch (error) {
-  console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+if (GREYNOISE_API_KEY === "") {
+  console.error("Error: GREYNOISE_API_KEY is required.");
   console.error("Make sure you have set the GREYNOISE_API_KEY environment variable");
   process.exit(1);
+}
+
+async function fetchGreyNoise(endpoint, apiBase, apiKey, params = {}) {
+  const url = new URL(`${apiBase}${endpoint}`);
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      url.searchParams.append(key, String(value));
+    }
+  });
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      key: apiKey,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "Could not parse error response");
+    throw new Error(`GreyNoise API error: ${response.status} - ${errorText}`);
+  }
+
+  return await response.json();
+}
+
+async function postToGreyNoise(endpoint, apiBase, apiKey, body) {
+  const url = new URL(`${apiBase}${endpoint}`);
+
+  const response = await fetch(url.toString(), {
+    method: "POST",
+    headers: {
+      key: apiKey,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "Could not parse error response");
+    throw new Error(`GreyNoise API error: ${response.status} - ${errorText}`);
+  }
+
+  return await response.json();
 }
 
 // Sample data for testing
@@ -187,7 +230,7 @@ const testCases = {
     func: async () => {
       console.log("Testing GNQL Stats endpoint");
       const query = encodeURIComponent(TEST_DATA.gnqlQuery);
-      const endpoint = `v2/experimental/gnql/stats?query=${query}&count=5`;
+      const endpoint = `v3/gnql/stats?query=${query}&count=5`;
       console.log(`Endpoint: ${endpoint}`);
       return await fetchGreyNoise(endpoint, GREYNOISE_API_BASE, GREYNOISE_API_KEY);
     },


### PR DESCRIPTION
## Summary
- move the gnql-stats tool from the sunset v2 endpoint to /v3/gnql/stats
- pass GNQL stats query params through the shared request helper
- update v3 GNQL stats response typing/formatting and the standalone test harness/docs example

## Tests
- npm run build
- npm test -- --runInBand

Live API smoke test was skipped because GREYNOISE_API_KEY is not set in this checkout.