### PR TITLE
Add test harness to CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,28 @@ jobs:
         with:
           name: greynoise-mcp-server-mcpb
           path: "*.mcpb"
+
+  # Live-API integration check: drives every tool/prompt/resource through a real MCP client.
+  # Reads-only (no GN_TEST_WORKSPACE, so it never mutates). Requires the GREYNOISE_API_KEY repo secret;
+  # skips cleanly when the secret is absent (e.g. fork PRs, which don't receive secrets).
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Validate against live GreyNoise API
+        env:
+          GREYNOISE_API_KEY: ${{ secrets.GREYNOISE_API_KEY }}
+        run: |
+          if [ -z "$GREYNOISE_API_KEY" ]; then
+            echo "::warning::GREYNOISE_API_KEY secret not set — skipping live validation"
+            exit 0
+          fi
+          npm run validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,10 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - name: Validate against live GreyNoise API
+      - name: Validate against live GreyNoise API (reads-only)
         env:
           GREYNOISE_API_KEY: ${{ secrets.GREYNOISE_API_KEY }}
+          MCP_VALIDATE_READONLY: "1"
         run: |
           if [ -z "$GREYNOISE_API_KEY" ]; then
             echo "::warning::GREYNOISE_API_KEY secret not set — skipping live validation"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,9 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - name: Validate against live GreyNoise API (reads-only)
+      - name: Validate against live GreyNoise API (full, incl. write round-trip)
         env:
           GREYNOISE_API_KEY: ${{ secrets.GREYNOISE_API_KEY }}
-          MCP_VALIDATE_READONLY: "1"
         run: |
           if [ -z "$GREYNOISE_API_KEY" ]; then
             echo "::warning::GREYNOISE_API_KEY secret not set — skipping live validation"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "version": "node scripts/sync-version.mjs && git add manifest.json",
     "build": "tsup && chmod 755 build/index.js",
     "pack:mcpb": "npx --yes @anthropic-ai/mcpb pack",
+    "validate": "node scripts/validate.mjs",
     "typecheck": "tsc --noEmit",
     "build:dev": "tsup src/index.ts --format esm --target node18 --sourcemap",
     "build:standalone": "npm run build && npm pack && echo 'Package ready for npx distribution'",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "tsup && chmod 755 build/index.js",
     "pack:mcpb": "npx --yes @anthropic-ai/mcpb pack",
     "validate": "node scripts/validate.mjs",
+    "validate:readonly": "MCP_VALIDATE_READONLY=1 node scripts/validate.mjs",
     "typecheck": "tsc --noEmit",
     "build:dev": "tsup src/index.ts --format esm --target node18 --sourcemap",
     "build:standalone": "npm run build && npm pack && echo 'Package ready for npx distribution'",

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -11,9 +11,9 @@
 // Env:
 //   GREYNOISE_API_KEY   required (passed through to the server)
 //   MCP_SERVER_CMD      server entry to spawn (default: "node build/index.js")
-//   GN_RUN_WRITES=1     run the create->delete round-trip for the operational (write) tools.
-//                       Workspace is resolved from the key (/v1/account) — no workspace id needed.
-//                       Use a DISPOSABLE workspace key: it creates + deletes "mcp-validate-DELETE-ME" resources.
+//   MCP_VALIDATE_READONLY=1  skip the operational write round-trip (create->delete). Default is to RUN it,
+//                       resolving the workspace from the key (/v1/account) — no workspace id needed.
+//                       Use a DISPOSABLE workspace key: the round-trip creates + deletes "mcp-validate-DELETE-ME".
 //   GREYNOISE_API_BASE  optional; forwarded to the server
 //
 // Any created resource is tracked and force-deleted in a finally block, so a mid-run crash
@@ -28,9 +28,9 @@ if (!process.env.GREYNOISE_API_KEY) {
 }
 
 const [cmd, ...cmdArgs] = (process.env.MCP_SERVER_CMD ?? "node build/index.js").split(" ");
-// Opt-in to the mutating create->delete round-trip. Workspace is resolved from the key (/v1/account),
-// so no workspace id is needed — this flag is purely a safety switch (off in reads-only CI).
-const runWrites = process.env.GN_RUN_WRITES === "1";
+// The create->delete round-trip runs by default (workspace resolved from the key via /v1/account).
+// CI opts out with MCP_VALIDATE_READONLY=1 so it never mutates a workspace.
+const runWrites = process.env.MCP_VALIDATE_READONLY !== "1";
 
 const results = [];
 const record = (kind, name, detail = "") => results.push({ kind, name, detail });
@@ -87,7 +87,7 @@ async function main() {
     const { prompts } = await client.listPrompts();
     const { resources } = await client.listResources().catch(() => ({ resources: [] }));
     console.log(`Discovered ${tools.length} tools, ${prompts.length} prompts, ${resources.length} static resources.`);
-    console.log(runWrites ? "Write round-trip: ON (GN_RUN_WRITES=1)\n" : "Write round-trip: OFF (set GN_RUN_WRITES=1 to enable)\n");
+    console.log(runWrites ? "Write round-trip: ON\n" : "Write round-trip: OFF (MCP_VALIDATE_READONLY=1)\n");
 
     // --- discover live fixtures from the server itself ---
     const now = new Date(), weekAgo = new Date(now.getTime() - 7 * 864e5), q90 = new Date(now.getTime() - 90 * 864e5);
@@ -136,7 +136,7 @@ async function main() {
     for (const t of tools) {
       if (writeTools.has(t.name)) continue;
       if (roundTripReads.has(t.name)) {
-        if (!runWrites) record("SKIPPED", t.name, "exercised only in the write round-trip (GN_RUN_WRITES=1)");
+        if (!runWrites) record("SKIPPED", t.name, "reads-only mode (MCP_VALIDATE_READONLY=1)");
         continue;
       }
       const args = fixtures[t.name];
@@ -168,7 +168,7 @@ async function main() {
 
     console.log("── Write tools (round-trip) ──");
     if (!runWrites) {
-      for (const n of writeTools) record("SKIPPED", n, "set GN_RUN_WRITES=1 to run the create->delete round-trip");
+      for (const n of writeTools) record("SKIPPED", n, "reads-only mode (MCP_VALIDATE_READONLY=1)");
     } else {
       await writeRoundTrip(client);
     }

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -38,10 +38,11 @@ async function callTool(client, name, args, { expectError = false } = {}) {
     const r = await client.callTool({ name, arguments: args });
     const text = r.content?.find((x) => x.type === "text")?.text ?? "";
     if (r.isError) {
-      if (isSchemaFail(text)) return record("FAIL", name, "schema/validation: " + text.slice(0, 160));
       if (isGated(text)) return record("GATED", name);
+      if (/Rate limited \(429\)|\b429\b/.test(text)) return record("WARN", name, text.slice(0, 120));
       if (expectError) return record("PASS", name, "rejected as expected");
-      return record("WARN", name, text.slice(0, 120));
+      // any other error — 4xx/5xx/timeout/schema — is a hard failure
+      return record("FAIL", name, text.slice(0, 160));
     }
     return record("PASS", name, r.structuredContent !== undefined ? "+structured" : "");
   } catch (e) {
@@ -98,7 +99,8 @@ async function main() {
     "export-sessions-pcap": { ...range, size: 1 },
     "bsi-lookup": { ip }, "bsi-bulk-lookup": { ips: [ip] },
     "bsi-trust-stats": {}, "bsi-company-stats": {}, "bsi-category-stats": {},
-    "callback-ip-lookup": { ip }, "list-callback-ips": {}, "export-callback-ips": {}, "callback-overview": {},
+    "callback-ip-lookup": { ip }, "list-callback-ips": {}, "export-callback-ips": {},
+    "callback-overview": { days: 1 },
   };
   const writeTools = new Set([
     "create-blocklist", "update-blocklist", "delete-blocklist",
@@ -154,7 +156,7 @@ async function writeRoundTrip(client, workspace_id) {
   try {
     const r = await client.callTool({ name: "create-blocklist", arguments: { workspace_id, query: "classification:malicious", name: "mcp-validate-DELETE-ME", ip_limit: 10 } });
     const text = r.content?.find((x) => x.type === "text")?.text ?? "";
-    if (r.isError) { isGated(text) ? record("GATED", "create-blocklist") : record(isSchemaFail(text) ? "FAIL" : "WARN", "create-blocklist", text.slice(0, 120)); }
+    if (r.isError) { isGated(text) ? record("GATED", "create-blocklist") : record("FAIL", "create-blocklist", text.slice(0, 120)); }
     else { blId = r.structuredContent?.id; record("PASS", "create-blocklist", "+structured"); }
   } catch (e) { record("FAIL", "create-blocklist", String(e?.message).slice(0, 120)); }
   if (blId) {
@@ -170,7 +172,7 @@ async function writeRoundTrip(client, workspace_id) {
   try {
     const r = await client.callTool({ name: "create-alert", arguments: { workspace_id, name: "mcp-validate-DELETE-ME", query: "classification:malicious", schedule: { type: "daily", time_of_day: "09:00" }, recipients: [{ type: "email", value: "noreply@greynoise.io" }] } });
     const text = r.content?.find((x) => x.type === "text")?.text ?? "";
-    if (r.isError) { isGated(text) ? record("GATED", "create-alert") : record(isSchemaFail(text) ? "FAIL" : "WARN", "create-alert", text.slice(0, 120)); }
+    if (r.isError) { isGated(text) ? record("GATED", "create-alert") : record("FAIL", "create-alert", text.slice(0, 120)); }
     else { alId = r.structuredContent?.id; record("PASS", "create-alert", "+structured"); }
   } catch (e) { record("FAIL", "create-alert", String(e?.message).slice(0, 120)); }
   if (alId) {

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -11,9 +11,9 @@
 // Env:
 //   GREYNOISE_API_KEY   required (passed through to the server)
 //   MCP_SERVER_CMD      server entry to spawn (default: "node build/index.js")
-//   GN_WORKSPACE        workspace the key is tied to; when set, runs the write round-trip there.
-//                       (GN_TEST_WORKSPACE also accepted.) MUST be a disposable workspace —
-//                       the round-trip creates + deletes "mcp-validate-DELETE-ME" resources.
+//   GN_RUN_WRITES=1     run the create->delete round-trip for the operational (write) tools.
+//                       Workspace is resolved from the key (/v1/account) — no workspace id needed.
+//                       Use a DISPOSABLE workspace key: it creates + deletes "mcp-validate-DELETE-ME" resources.
 //   GREYNOISE_API_BASE  optional; forwarded to the server
 //
 // Any created resource is tracked and force-deleted in a finally block, so a mid-run crash
@@ -28,14 +28,16 @@ if (!process.env.GREYNOISE_API_KEY) {
 }
 
 const [cmd, ...cmdArgs] = (process.env.MCP_SERVER_CMD ?? "node build/index.js").split(" ");
-const writeWorkspace = process.env.GN_WORKSPACE || process.env.GN_TEST_WORKSPACE;
+// Opt-in to the mutating create->delete round-trip. Workspace is resolved from the key (/v1/account),
+// so no workspace id is needed — this flag is purely a safety switch (off in reads-only CI).
+const runWrites = process.env.GN_RUN_WRITES === "1";
 
 const results = [];
 const record = (kind, name, detail = "") => results.push({ kind, name, detail });
 const isGated = (t) => /entitled \(403\)|Authentication failed \(401\)|\b40[13]\b/.test(t);
 
 // resources created during the write round-trip; force-deleted in cleanup()
-const created = []; // { type: "blocklist"|"alert", workspace_id, id }
+const created = []; // { type: "blocklist"|"alert", id }
 const untrack = (id) => {
   const i = created.findIndex((c) => c.id === id);
   if (i >= 0) created.splice(i, 1);
@@ -65,7 +67,7 @@ async function cleanup(client) {
     const tool = c.type === "blocklist" ? "delete-blocklist" : "delete-alert";
     const idArg = c.type === "blocklist" ? { blocklist_id: c.id } : { alert_id: c.id };
     try {
-      const r = await client.callTool({ name: tool, arguments: { workspace_id: c.workspace_id, ...idArg } });
+      const r = await client.callTool({ name: tool, arguments: idArg });
       console.log(`  ${r.isError ? "⚠️  FAILED to delete" : "✅ deleted"} ${c.type} ${c.id}`);
       if (!r.isError) untrack(c.id);
     } catch (e) {
@@ -85,7 +87,7 @@ async function main() {
     const { prompts } = await client.listPrompts();
     const { resources } = await client.listResources().catch(() => ({ resources: [] }));
     console.log(`Discovered ${tools.length} tools, ${prompts.length} prompts, ${resources.length} static resources.`);
-    console.log(writeWorkspace ? `Write round-trip: ON (workspace ${writeWorkspace})\n` : "Write round-trip: OFF (no GN_WORKSPACE)\n");
+    console.log(runWrites ? "Write round-trip: ON (GN_RUN_WRITES=1)\n" : "Write round-trip: OFF (set GN_RUN_WRITES=1 to enable)\n");
 
     // --- discover live fixtures from the server itself ---
     const now = new Date(), weekAgo = new Date(now.getTime() - 7 * 864e5), q90 = new Date(now.getTime() - 90 * 864e5);
@@ -101,7 +103,6 @@ async function main() {
     } catch {}
 
     const ip = "8.8.8.8", range = { start_time: iso(weekAgo), end_time: iso(now) };
-    const ws = writeWorkspace ? { workspace_id: writeWorkspace } : null;
     const fixtures = {
       "lookup-ip-context": { ip }, "quick-check-ip": { ip }, "multi-ip-check": { ips: [ip, "1.1.1.1"] },
       "gnql-query": { query: "classification:malicious", size: 1 },
@@ -125,7 +126,7 @@ async function main() {
       "bsi-lookup": { ip }, "bsi-bulk-lookup": { ips: [ip] },
       "bsi-trust-stats": {}, "bsi-company-stats": {}, "bsi-category-stats": {},
       "callback-ip-lookup": { ip }, "list-callback-ips": {}, "export-callback-ips": {}, "callback-overview": { days: 1 },
-      "list-blocklists": ws, "list-alerts": ws,
+      "list-blocklists": {}, "list-alerts": {},
     };
     // write tools + id-scoped reads are exercised in the round-trip, not the read loop
     const writeTools = new Set(["create-blocklist", "update-blocklist", "delete-blocklist", "create-alert", "update-alert", "delete-alert", "enable-alert", "disable-alert", "test-alert-webhook"]);
@@ -135,12 +136,12 @@ async function main() {
     for (const t of tools) {
       if (writeTools.has(t.name)) continue;
       if (roundTripReads.has(t.name)) {
-        if (!writeWorkspace) record("SKIPPED", t.name, "needs GN_WORKSPACE (round-trip)");
+        if (!runWrites) record("SKIPPED", t.name, "exercised only in the write round-trip (GN_RUN_WRITES=1)");
         continue;
       }
       const args = fixtures[t.name];
       if (args === undefined) { record("SKIPPED", t.name, "no fixture"); continue; }
-      if (args === null) { record("SKIPPED", t.name, writeWorkspace ? "prerequisite fixture unavailable" : "needs GN_WORKSPACE"); continue; }
+      if (args === null) { record("SKIPPED", t.name, "prerequisite fixture unavailable (no live data)"); continue; }
       await callTool(client, t.name, args);
     }
 
@@ -166,10 +167,10 @@ async function main() {
     }
 
     console.log("── Write tools (round-trip) ──");
-    if (!writeWorkspace) {
-      for (const n of writeTools) record("SKIPPED", n, "set GN_WORKSPACE to a disposable workspace to round-trip writes");
+    if (!runWrites) {
+      for (const n of writeTools) record("SKIPPED", n, "set GN_RUN_WRITES=1 to run the create->delete round-trip");
     } else {
-      await writeRoundTrip(client, writeWorkspace);
+      await writeRoundTrip(client);
     }
   } finally {
     await cleanup(client).catch((e) => console.error("cleanup error:", e));
@@ -178,37 +179,38 @@ async function main() {
   report();
 }
 
-async function createTracked(client, name, args, type, workspace_id) {
+// workspace_id is omitted throughout — every operational tool defaults to the key's workspace (/v1/account)
+async function createTracked(client, name, args, type) {
   const r = await callTool(client, name, args);
   const id = r && !r.isError ? r.structuredContent?.id : undefined;
-  if (id) created.push({ type, workspace_id, id });
+  if (id) created.push({ type, id });
   return id;
 }
 
-async function writeRoundTrip(client, workspace_id) {
+async function writeRoundTrip(client) {
   // Blocklist lifecycle
   const blId = await createTracked(client, "create-blocklist",
-    { workspace_id, query: "classification:malicious", name: "mcp-validate-DELETE-ME", ip_limit: 10 }, "blocklist", workspace_id);
+    { query: "classification:malicious", name: "mcp-validate-DELETE-ME", ip_limit: 10 }, "blocklist");
   if (blId) {
-    await callTool(client, "get-blocklist", { workspace_id, blocklist_id: blId });
-    await callTool(client, "get-blocklist-ips", { workspace_id, blocklist_id: blId });
-    await callTool(client, "update-blocklist", { workspace_id, blocklist_id: blId, query: "classification:malicious", enabled: false });
-    const r = await callTool(client, "delete-blocklist", { workspace_id, blocklist_id: blId });
+    await callTool(client, "get-blocklist", { blocklist_id: blId });
+    await callTool(client, "get-blocklist-ips", { blocklist_id: blId });
+    await callTool(client, "update-blocklist", { blocklist_id: blId, query: "classification:malicious", enabled: false });
+    const r = await callTool(client, "delete-blocklist", { blocklist_id: blId });
     if (r && !r.isError) untrack(blId);
   }
 
   // Alert lifecycle
   const alId = await createTracked(client, "create-alert",
-    { workspace_id, name: "mcp-validate-DELETE-ME", query: "classification:malicious", schedule: { type: "daily", time_of_day: "09:00" }, recipients: [{ type: "email", value: "noreply@greynoise.io" }] }, "alert", workspace_id);
+    { name: "mcp-validate-DELETE-ME", query: "classification:malicious", schedule: { type: "daily", time_of_day: "09:00" }, recipients: [{ type: "email", value: "noreply@greynoise.io" }] }, "alert");
   if (alId) {
-    await callTool(client, "get-alert", { workspace_id, alert_id: alId });
-    await callTool(client, "disable-alert", { workspace_id, alert_id: alId });
-    await callTool(client, "enable-alert", { workspace_id, alert_id: alId });
-    await callTool(client, "update-alert", { workspace_id, alert_id: alId, name: "mcp-validate-DELETE-ME", query: "classification:malicious", schedule: { type: "daily", time_of_day: "10:00" }, recipients: [{ type: "email", value: "noreply@greynoise.io" }] });
-    const r = await callTool(client, "delete-alert", { workspace_id, alert_id: alId });
+    await callTool(client, "get-alert", { alert_id: alId });
+    await callTool(client, "disable-alert", { alert_id: alId });
+    await callTool(client, "enable-alert", { alert_id: alId });
+    await callTool(client, "update-alert", { alert_id: alId, name: "mcp-validate-DELETE-ME", query: "classification:malicious", schedule: { type: "daily", time_of_day: "10:00" }, recipients: [{ type: "email", value: "noreply@greynoise.io" }] });
+    const r = await callTool(client, "delete-alert", { alert_id: alId });
     if (r && !r.isError) untrack(alId);
   }
-  await callTool(client, "test-alert-webhook", { workspace_id, url: "https://example.com/greynoise-mcp-validate" });
+  await callTool(client, "test-alert-webhook", { url: "https://example.com/greynoise-mcp-validate" });
 }
 
 function report() {

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+// Outside-in validation harness: connects to the MCP server as a black-box MCP client,
+// exercises every tool/prompt/resource, and classifies results.
+//
+//   PASS         tool returned successfully
+//   GATED        entitlement/auth denied (403/401) — expected on plans without the feature
+//   WARN         empty result / not-found (often fixture-related, not a server bug)
+//   SKIPPED      no fixture / prerequisite unavailable
+//   FAIL         schema-validation error, protocol error, or crash  <-- gate fails on these
+//
+// Env:
+//   GREYNOISE_API_KEY   required (passed through to the server)
+//   MCP_SERVER_CMD      server entry to spawn (default: "node build/index.js")
+//   GN_TEST_WORKSPACE   optional; if set, runs create->delete round-trips for write tools there
+//   GREYNOISE_API_BASE  optional; forwarded to the server
+//
+// Exits non-zero if any FAIL.
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+if (!process.env.GREYNOISE_API_KEY) {
+  console.error("GREYNOISE_API_KEY is required");
+  process.exit(2);
+}
+
+const [cmd, ...cmdArgs] = (process.env.MCP_SERVER_CMD ?? "node build/index.js").split(" ");
+const testWorkspace = process.env.GN_TEST_WORKSPACE;
+
+const results = [];
+const record = (kind, name, detail = "") => results.push({ kind, name, detail });
+
+const isGated = (t) => /entitled \(403\)|Authentication failed \(401\)|\b40[13]\b/.test(t);
+const isSchemaFail = (t) => /schema validation|invalid_type|"expected":|ZodError|Invalid input/.test(t);
+
+async function callTool(client, name, args, { expectError = false } = {}) {
+  try {
+    const r = await client.callTool({ name, arguments: args });
+    const text = r.content?.find((x) => x.type === "text")?.text ?? "";
+    if (r.isError) {
+      if (isSchemaFail(text)) return record("FAIL", name, "schema/validation: " + text.slice(0, 160));
+      if (isGated(text)) return record("GATED", name);
+      if (expectError) return record("PASS", name, "rejected as expected");
+      return record("WARN", name, text.slice(0, 120));
+    }
+    return record("PASS", name, r.structuredContent !== undefined ? "+structured" : "");
+  } catch (e) {
+    record("FAIL", name, "threw: " + String(e?.message ?? e).slice(0, 160));
+    return null;
+  }
+}
+
+async function main() {
+  const transport = new StdioClientTransport({ command: cmd, args: cmdArgs, env: { ...process.env } });
+  const client = new Client({ name: "gn-mcp-validator", version: "1.0.0" });
+  await client.connect(transport);
+
+  const { tools } = await client.listTools();
+  const { prompts } = await client.listPrompts();
+  const { resourceTemplates } = await client.listResourceTemplates().catch(() => ({ resourceTemplates: [] }));
+  const { resources } = await client.listResources().catch(() => ({ resources: [] }));
+  console.log(`Discovered ${tools.length} tools, ${prompts.length} prompts, ${resources.length}+${resourceTemplates.length} resources.\n`);
+
+  // --- discover live fixtures from the server itself ---
+  let tagSlug, sessionId;
+  const now = new Date(), weekAgo = new Date(now.getTime() - 7 * 864e5);
+  const iso = (d) => d.toISOString();
+  try {
+    const r = await client.callTool({ name: "get-tag-list", arguments: {} });
+    tagSlug = JSON.parse(r.content[0].text)?.tags?.[0]?.slug;
+  } catch {}
+  try {
+    const r = await client.callTool({ name: "search-sessions", arguments: { start_time: iso(weekAgo), end_time: iso(now), page_size: 1 } });
+    sessionId = JSON.parse(r.structuredContent ? JSON.stringify(r.structuredContent) : "{}")?.data?.[0]?._id;
+  } catch {}
+
+  // --- read-tool fixtures ---
+  const ip = "8.8.8.8", range = { start_time: iso(weekAgo), end_time: iso(now) };
+  const fixtures = {
+    "lookup-ip-context": { ip }, "quick-check-ip": { ip }, "multi-ip-check": { ips: [ip, "1.1.1.1"] },
+    "gnql-query": { query: "classification:malicious", size: 1 },
+    "gnql-metadata-query": { query: "tags:Mirai", size: 2, format: "csv" },
+    "gnql-stats": { query: "classification:malicious" },
+    "gnql-timeseries": { query: `ip:${ip}` },
+    "gnql-timeseries-stats": { query: "classification:malicious", interval: "day" },
+    "get-tag-list": {}, "search-tags": { query: "mirai" },
+    "get-tag-details": tagSlug ? { id_or_slug: tagSlug } : null,
+    "get-tag-activity": tagSlug ? { id_or_slug: tagSlug } : null,
+    "analyze-tags-activity": { query: "mirai", days: "1" },
+    "get-cve-details": { cve_id: "CVE-2021-44228" }, "get-trending-vulnerabilities": {},
+    "search-sessions": { ...range, page_size: 2 }, "session-fields": {},
+    "session-counts": { ...range, fields: "classification" },
+    "session-connections": { ...range, src_field: "source.ip", dest_field: "destination.ip" },
+    "session-timeseries": { ...range }, "session-unique-values": { ...range, field: "source.ip" },
+    "get-session": sessionId ? { session_id: sessionId } : null,
+    "get-session-pcap": sessionId ? { session_id: sessionId } : null,
+    "export-session-data": sessionId ? { session_id: sessionId } : null,
+    "export-sessions-pcap": { ...range, size: 1 },
+    "bsi-lookup": { ip }, "bsi-bulk-lookup": { ips: [ip] },
+    "bsi-trust-stats": {}, "bsi-company-stats": {}, "bsi-category-stats": {},
+    "callback-ip-lookup": { ip }, "list-callback-ips": {}, "export-callback-ips": {}, "callback-overview": {},
+  };
+  const writeTools = new Set([
+    "create-blocklist", "update-blocklist", "delete-blocklist",
+    "create-alert", "update-alert", "delete-alert", "enable-alert", "disable-alert", "test-alert-webhook",
+  ]);
+
+  console.log("── Read tools ──");
+  for (const t of tools) {
+    if (writeTools.has(t.name)) continue;
+    const args = fixtures[t.name];
+    if (args === undefined) { record("SKIPPED", t.name, "no fixture"); continue; }
+    if (args === null) { record("SKIPPED", t.name, "prerequisite fixture unavailable"); continue; }
+    await callTool(client, t.name, args);
+  }
+
+  console.log("── Prompts ──");
+  const promptArgs = {
+    "ip-threat-analysis": { ip }, "cve-analysis": { cve_id: "CVE-2021-44228" },
+    "vendor-threat-report": { vendor: "Apache", timeframe: "30" },
+    "emerging-threat-report": {},
+    "security-posture-assessment": { organization: "Acme", technologies: "Apache, nginx" },
+    "threat-hunting": { indicator_type: "ip", indicator_value: ip, environment: "prod" },
+  };
+  for (const p of prompts) {
+    try {
+      const r = await client.getPrompt({ name: p.name, arguments: promptArgs[p.name] ?? {} });
+      record(r.messages?.length ? "PASS" : "WARN", "prompt:" + p.name);
+    } catch (e) { record("FAIL", "prompt:" + p.name, String(e?.message).slice(0, 120)); }
+  }
+
+  console.log("── Resources ──");
+  const uris = [`greynoise://ip/${ip}`, "greynoise://cve/CVE-2021-44228", ...(tagSlug ? [`greynoise://tag/${tagSlug}`] : []),
+    ...resources.map((r) => r.uri)];
+  for (const uri of uris) {
+    try { const r = await client.readResource({ uri }); record(r.contents?.length ? "PASS" : "WARN", "res:" + uri); }
+    catch (e) { const m = String(e?.message); record(isGated(m) ? "GATED" : "FAIL", "res:" + uri, m.slice(0, 120)); }
+  }
+
+  console.log("── Write tools (operational) ──");
+  if (!testWorkspace) {
+    for (const n of writeTools) record("SKIPPED", n, "set GN_TEST_WORKSPACE to a disposable workspace to round-trip writes");
+  } else {
+    await writeRoundTrip(client, testWorkspace);
+  }
+
+  await client.close();
+  report();
+}
+
+async function writeRoundTrip(client, workspace_id) {
+  // Blocklist lifecycle
+  let blId;
+  try {
+    const r = await client.callTool({ name: "create-blocklist", arguments: { workspace_id, query: "classification:malicious", name: "mcp-validate-DELETE-ME", ip_limit: 10 } });
+    const text = r.content?.find((x) => x.type === "text")?.text ?? "";
+    if (r.isError) { isGated(text) ? record("GATED", "create-blocklist") : record(isSchemaFail(text) ? "FAIL" : "WARN", "create-blocklist", text.slice(0, 120)); }
+    else { blId = r.structuredContent?.id; record("PASS", "create-blocklist", "+structured"); }
+  } catch (e) { record("FAIL", "create-blocklist", String(e?.message).slice(0, 120)); }
+  if (blId) {
+    await callTool(client, "get-blocklist", { workspace_id, blocklist_id: blId });
+    await callTool(client, "get-blocklist-ips", { workspace_id, blocklist_id: blId });
+    await callTool(client, "update-blocklist", { workspace_id, blocklist_id: blId, query: "classification:malicious", enabled: false });
+    await callTool(client, "delete-blocklist", { workspace_id, blocklist_id: blId });
+  }
+  await callTool(client, "list-blocklists", { workspace_id });
+
+  // Alert lifecycle
+  let alId;
+  try {
+    const r = await client.callTool({ name: "create-alert", arguments: { workspace_id, name: "mcp-validate-DELETE-ME", query: "classification:malicious", schedule: { type: "daily", time_of_day: "09:00" }, recipients: [{ type: "email", value: "noreply@greynoise.io" }] } });
+    const text = r.content?.find((x) => x.type === "text")?.text ?? "";
+    if (r.isError) { isGated(text) ? record("GATED", "create-alert") : record(isSchemaFail(text) ? "FAIL" : "WARN", "create-alert", text.slice(0, 120)); }
+    else { alId = r.structuredContent?.id; record("PASS", "create-alert", "+structured"); }
+  } catch (e) { record("FAIL", "create-alert", String(e?.message).slice(0, 120)); }
+  if (alId) {
+    await callTool(client, "get-alert", { workspace_id, alert_id: alId });
+    await callTool(client, "disable-alert", { workspace_id, alert_id: alId });
+    await callTool(client, "enable-alert", { workspace_id, alert_id: alId });
+    await callTool(client, "delete-alert", { workspace_id, alert_id: alId });
+  }
+  await callTool(client, "list-alerts", { workspace_id });
+  await callTool(client, "test-alert-webhook", { workspace_id, url: "https://example.com/greynoise-mcp-validate" });
+}
+
+function report() {
+  const by = (k) => results.filter((r) => r.kind === k);
+  const order = ["FAIL", "WARN", "GATED", "SKIPPED", "PASS"];
+  console.log("\n──────── RESULTS ────────");
+  for (const r of results.sort((a, b) => order.indexOf(a.kind) - order.indexOf(b.kind))) {
+    const icon = { PASS: "✅", GATED: "🔒", WARN: "⚠️ ", SKIPPED: "⏭️ ", FAIL: "❌" }[r.kind];
+    console.log(`${icon} ${r.name}${r.detail ? " — " + r.detail : ""}`);
+  }
+  const c = Object.fromEntries(order.map((k) => [k, by(k).length]));
+  console.log(`\nSUMMARY: ${c.PASS} pass · ${c.GATED} gated · ${c.WARN} warn · ${c.SKIPPED} skipped · ${c.FAIL} fail`);
+  if (c.FAIL > 0) { console.error("\n❌ VALIDATION FAILED — do not promote."); process.exit(1); }
+  console.log("\n✅ No hard failures. Review warnings before promoting.");
+}
+
+main().catch((e) => { console.error("harness error:", e); process.exit(1); });

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -2,19 +2,22 @@
 // Outside-in validation harness: connects to the MCP server as a black-box MCP client,
 // exercises every tool/prompt/resource, and classifies results.
 //
-//   PASS         tool returned successfully
-//   GATED        entitlement/auth denied (403/401) — expected on plans without the feature
-//   WARN         empty result / not-found (often fixture-related, not a server bug)
-//   SKIPPED      no fixture / prerequisite unavailable
-//   FAIL         schema-validation error, protocol error, or crash  <-- gate fails on these
+//   PASS      tool returned successfully
+//   GATED     entitlement/auth denied (401/403) — expected on plans without the feature
+//   WARN      rate-limited (429)
+//   SKIPPED   no fixture / prerequisite unavailable
+//   FAIL      4xx/5xx/timeout/schema/protocol/crash  <-- gate fails on these
 //
 // Env:
 //   GREYNOISE_API_KEY   required (passed through to the server)
 //   MCP_SERVER_CMD      server entry to spawn (default: "node build/index.js")
-//   GN_TEST_WORKSPACE   optional; if set, runs create->delete round-trips for write tools there
+//   GN_WORKSPACE        workspace the key is tied to; when set, runs the write round-trip there.
+//                       (GN_TEST_WORKSPACE also accepted.) MUST be a disposable workspace —
+//                       the round-trip creates + deletes "mcp-validate-DELETE-ME" resources.
 //   GREYNOISE_API_BASE  optional; forwarded to the server
 //
-// Exits non-zero if any FAIL.
+// Any created resource is tracked and force-deleted in a finally block, so a mid-run crash
+// never leaves orphans. Exits non-zero if any FAIL.
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
@@ -25,30 +28,51 @@ if (!process.env.GREYNOISE_API_KEY) {
 }
 
 const [cmd, ...cmdArgs] = (process.env.MCP_SERVER_CMD ?? "node build/index.js").split(" ");
-const testWorkspace = process.env.GN_TEST_WORKSPACE;
+const writeWorkspace = process.env.GN_WORKSPACE || process.env.GN_TEST_WORKSPACE;
 
 const results = [];
 const record = (kind, name, detail = "") => results.push({ kind, name, detail });
-
 const isGated = (t) => /entitled \(403\)|Authentication failed \(401\)|\b40[13]\b/.test(t);
-const isSchemaFail = (t) => /schema validation|invalid_type|"expected":|ZodError|Invalid input/.test(t);
 
-async function callTool(client, name, args, { expectError = false } = {}) {
+// resources created during the write round-trip; force-deleted in cleanup()
+const created = []; // { type: "blocklist"|"alert", workspace_id, id }
+const untrack = (id) => {
+  const i = created.findIndex((c) => c.id === id);
+  if (i >= 0) created.splice(i, 1);
+};
+
+async function callTool(client, name, args) {
   try {
     const r = await client.callTool({ name, arguments: args });
     const text = r.content?.find((x) => x.type === "text")?.text ?? "";
     if (r.isError) {
-      if (isGated(text)) return record("GATED", name);
-      if (/Rate limited \(429\)|\b429\b/.test(text)) return record("WARN", name, text.slice(0, 120));
-      if (expectError) return record("PASS", name, "rejected as expected");
-      // any other error — 4xx/5xx/timeout/schema — is a hard failure
-      return record("FAIL", name, text.slice(0, 160));
+      if (isGated(text)) return (record("GATED", name), r);
+      if (/Rate limited \(429\)|\b429\b/.test(text)) return (record("WARN", name, text.slice(0, 120)), r);
+      return (record("FAIL", name, text.slice(0, 160)), r);
     }
-    return record("PASS", name, r.structuredContent !== undefined ? "+structured" : "");
+    record("PASS", name, r.structuredContent !== undefined ? "+structured" : "");
+    return r;
   } catch (e) {
     record("FAIL", name, "threw: " + String(e?.message ?? e).slice(0, 160));
     return null;
   }
+}
+
+async function cleanup(client) {
+  if (created.length === 0) return;
+  console.log(`\n── Cleanup: deleting ${created.length} leftover resource(s) ──`);
+  for (const c of [...created]) {
+    const tool = c.type === "blocklist" ? "delete-blocklist" : "delete-alert";
+    const idArg = c.type === "blocklist" ? { blocklist_id: c.id } : { alert_id: c.id };
+    try {
+      const r = await client.callTool({ name: tool, arguments: { workspace_id: c.workspace_id, ...idArg } });
+      console.log(`  ${r.isError ? "⚠️  FAILED to delete" : "✅ deleted"} ${c.type} ${c.id}`);
+      if (!r.isError) untrack(c.id);
+    } catch (e) {
+      console.log(`  ⚠️  FAILED to delete ${c.type} ${c.id}: ${String(e?.message).slice(0, 100)}`);
+    }
+  }
+  if (created.length) console.error(`\n⚠️  ORPHANS REMAIN — delete manually: ${JSON.stringify(created)}`);
 }
 
 async function main() {
@@ -56,147 +80,148 @@ async function main() {
   const client = new Client({ name: "gn-mcp-validator", version: "1.0.0" });
   await client.connect(transport);
 
-  const { tools } = await client.listTools();
-  const { prompts } = await client.listPrompts();
-  const { resourceTemplates } = await client.listResourceTemplates().catch(() => ({ resourceTemplates: [] }));
-  const { resources } = await client.listResources().catch(() => ({ resources: [] }));
-  console.log(`Discovered ${tools.length} tools, ${prompts.length} prompts, ${resources.length}+${resourceTemplates.length} resources.\n`);
-
-  // --- discover live fixtures from the server itself ---
-  let tagSlug, sessionId;
-  const now = new Date(), weekAgo = new Date(now.getTime() - 7 * 864e5);
-  const iso = (d) => d.toISOString();
   try {
-    const r = await client.callTool({ name: "get-tag-list", arguments: {} });
-    tagSlug = JSON.parse(r.content[0].text)?.tags?.[0]?.slug;
-  } catch {}
-  try {
-    const r = await client.callTool({ name: "search-sessions", arguments: { start_time: iso(weekAgo), end_time: iso(now), page_size: 1 } });
-    sessionId = JSON.parse(r.structuredContent ? JSON.stringify(r.structuredContent) : "{}")?.data?.[0]?._id;
-  } catch {}
+    const { tools } = await client.listTools();
+    const { prompts } = await client.listPrompts();
+    const { resources } = await client.listResources().catch(() => ({ resources: [] }));
+    console.log(`Discovered ${tools.length} tools, ${prompts.length} prompts, ${resources.length} static resources.`);
+    console.log(writeWorkspace ? `Write round-trip: ON (workspace ${writeWorkspace})\n` : "Write round-trip: OFF (no GN_WORKSPACE)\n");
 
-  // --- read-tool fixtures ---
-  const ip = "8.8.8.8", range = { start_time: iso(weekAgo), end_time: iso(now) };
-  const fixtures = {
-    "lookup-ip-context": { ip }, "quick-check-ip": { ip }, "multi-ip-check": { ips: [ip, "1.1.1.1"] },
-    "gnql-query": { query: "classification:malicious", size: 1 },
-    "gnql-metadata-query": { query: "tags:Mirai", size: 2, format: "csv" },
-    "gnql-stats": { query: "classification:malicious" },
-    "gnql-timeseries": { query: `ip:${ip}` },
-    "gnql-timeseries-stats": { query: "classification:malicious", interval: "day" },
-    "get-tag-list": {}, "search-tags": { query: "mirai" },
-    "get-tag-details": tagSlug ? { id_or_slug: tagSlug } : null,
-    "get-tag-activity": tagSlug ? { id_or_slug: tagSlug } : null,
-    "analyze-tags-activity": { query: "mirai", days: "1" },
-    "get-cve-details": { cve_id: "CVE-2021-44228" }, "get-trending-vulnerabilities": {},
-    "search-sessions": { ...range, page_size: 2 }, "session-fields": {},
-    "session-counts": { ...range, fields: "classification" },
-    "session-connections": { ...range, src_field: "source.ip", dest_field: "destination.ip" },
-    "session-timeseries": { ...range }, "session-unique-values": { ...range, field: "source.ip" },
-    "get-session": sessionId ? { session_id: sessionId } : null,
-    "get-session-pcap": sessionId ? { session_id: sessionId } : null,
-    "export-session-data": sessionId ? { session_id: sessionId } : null,
-    "export-sessions-pcap": { ...range, size: 1 },
-    "bsi-lookup": { ip }, "bsi-bulk-lookup": { ips: [ip] },
-    "bsi-trust-stats": {}, "bsi-company-stats": {}, "bsi-category-stats": {},
-    "callback-ip-lookup": { ip }, "list-callback-ips": {}, "export-callback-ips": {},
-    "callback-overview": { days: 1 },
-  };
-  const writeTools = new Set([
-    "create-blocklist", "update-blocklist", "delete-blocklist",
-    "create-alert", "update-alert", "delete-alert", "enable-alert", "disable-alert", "test-alert-webhook",
-  ]);
-
-  console.log("── Read tools ──");
-  for (const t of tools) {
-    if (writeTools.has(t.name)) continue;
-    const args = fixtures[t.name];
-    if (args === undefined) { record("SKIPPED", t.name, "no fixture"); continue; }
-    if (args === null) { record("SKIPPED", t.name, "prerequisite fixture unavailable"); continue; }
-    await callTool(client, t.name, args);
-  }
-
-  console.log("── Prompts ──");
-  const promptArgs = {
-    "ip-threat-analysis": { ip }, "cve-analysis": { cve_id: "CVE-2021-44228" },
-    "vendor-threat-report": { vendor: "Apache", timeframe: "30" },
-    "emerging-threat-report": {},
-    "security-posture-assessment": { organization: "Acme", technologies: "Apache, nginx" },
-    "threat-hunting": { indicator_type: "ip", indicator_value: ip, environment: "prod" },
-  };
-  for (const p of prompts) {
+    // --- discover live fixtures from the server itself ---
+    const now = new Date(), weekAgo = new Date(now.getTime() - 7 * 864e5), q90 = new Date(now.getTime() - 90 * 864e5);
+    const iso = (d) => d.toISOString();
+    let tagSlug, sessionId;
     try {
-      const r = await client.getPrompt({ name: p.name, arguments: promptArgs[p.name] ?? {} });
-      record(r.messages?.length ? "PASS" : "WARN", "prompt:" + p.name);
-    } catch (e) { record("FAIL", "prompt:" + p.name, String(e?.message).slice(0, 120)); }
-  }
+      const r = await client.callTool({ name: "get-tag-list", arguments: {} });
+      tagSlug = JSON.parse(r.content[0].text)?.tags?.[0]?.slug;
+    } catch {}
+    try {
+      const r = await client.callTool({ name: "search-sessions", arguments: { start_time: iso(q90), end_time: iso(now), page_size: 1 } });
+      sessionId = r.structuredContent?.data?.[0]?._id;
+    } catch {}
 
-  console.log("── Resources ──");
-  const uris = [`greynoise://ip/${ip}`, "greynoise://cve/CVE-2021-44228", ...(tagSlug ? [`greynoise://tag/${tagSlug}`] : []),
-    ...resources.map((r) => r.uri)];
-  for (const uri of uris) {
-    try { const r = await client.readResource({ uri }); record(r.contents?.length ? "PASS" : "WARN", "res:" + uri); }
-    catch (e) { const m = String(e?.message); record(isGated(m) ? "GATED" : "FAIL", "res:" + uri, m.slice(0, 120)); }
-  }
+    const ip = "8.8.8.8", range = { start_time: iso(weekAgo), end_time: iso(now) };
+    const ws = writeWorkspace ? { workspace_id: writeWorkspace } : null;
+    const fixtures = {
+      "lookup-ip-context": { ip }, "quick-check-ip": { ip }, "multi-ip-check": { ips: [ip, "1.1.1.1"] },
+      "gnql-query": { query: "classification:malicious", size: 1 },
+      "gnql-metadata-query": { query: "tags:Mirai", size: 2, format: "csv" },
+      "gnql-stats": { query: "classification:malicious" },
+      "gnql-timeseries": { query: `ip:${ip}` },
+      "gnql-timeseries-stats": { query: "classification:malicious", interval: "day" },
+      "get-tag-list": {}, "search-tags": { query: "mirai" },
+      "get-tag-details": tagSlug ? { id_or_slug: tagSlug } : null,
+      "get-tag-activity": tagSlug ? { id_or_slug: tagSlug } : null,
+      "analyze-tags-activity": { query: "mirai", days: "1" },
+      "get-cve-details": { cve_id: "CVE-2021-44228" }, "get-trending-vulnerabilities": {},
+      "search-sessions": { ...range, page_size: 2 }, "session-fields": {},
+      "session-counts": { ...range, fields: "classification" },
+      "session-connections": { ...range, src_field: "source.ip", dest_field: "destination.ip" },
+      "session-timeseries": { ...range }, "session-unique-values": { ...range, field: "source.ip" },
+      "get-session": sessionId ? { session_id: sessionId } : null,
+      "get-session-pcap": sessionId ? { session_id: sessionId } : null,
+      "export-session-data": sessionId ? { session_id: sessionId } : null,
+      "export-sessions-pcap": { ...range, size: 1 },
+      "bsi-lookup": { ip }, "bsi-bulk-lookup": { ips: [ip] },
+      "bsi-trust-stats": {}, "bsi-company-stats": {}, "bsi-category-stats": {},
+      "callback-ip-lookup": { ip }, "list-callback-ips": {}, "export-callback-ips": {}, "callback-overview": { days: 1 },
+      "list-blocklists": ws, "list-alerts": ws,
+    };
+    // write tools + id-scoped reads are exercised in the round-trip, not the read loop
+    const writeTools = new Set(["create-blocklist", "update-blocklist", "delete-blocklist", "create-alert", "update-alert", "delete-alert", "enable-alert", "disable-alert", "test-alert-webhook"]);
+    const roundTripReads = new Set(["get-blocklist", "get-blocklist-ips", "get-alert"]);
 
-  console.log("── Write tools (operational) ──");
-  if (!testWorkspace) {
-    for (const n of writeTools) record("SKIPPED", n, "set GN_TEST_WORKSPACE to a disposable workspace to round-trip writes");
-  } else {
-    await writeRoundTrip(client, testWorkspace);
-  }
+    console.log("── Read tools ──");
+    for (const t of tools) {
+      if (writeTools.has(t.name)) continue;
+      if (roundTripReads.has(t.name)) {
+        if (!writeWorkspace) record("SKIPPED", t.name, "needs GN_WORKSPACE (round-trip)");
+        continue;
+      }
+      const args = fixtures[t.name];
+      if (args === undefined) { record("SKIPPED", t.name, "no fixture"); continue; }
+      if (args === null) { record("SKIPPED", t.name, writeWorkspace ? "prerequisite fixture unavailable" : "needs GN_WORKSPACE"); continue; }
+      await callTool(client, t.name, args);
+    }
 
-  await client.close();
+    console.log("── Prompts ──");
+    const promptArgs = {
+      "ip-threat-analysis": { ip }, "cve-analysis": { cve_id: "CVE-2021-44228" },
+      "vendor-threat-report": { vendor: "Apache", timeframe: "30" }, "emerging-threat-report": {},
+      "security-posture-assessment": { organization: "Acme", technologies: "Apache, nginx" },
+      "threat-hunting": { indicator_type: "ip", indicator_value: ip, environment: "prod" },
+    };
+    for (const p of prompts) {
+      try {
+        const r = await client.getPrompt({ name: p.name, arguments: promptArgs[p.name] ?? {} });
+        record(r.messages?.length ? "PASS" : "WARN", "prompt:" + p.name);
+      } catch (e) { record("FAIL", "prompt:" + p.name, String(e?.message).slice(0, 120)); }
+    }
+
+    console.log("── Resources ──");
+    const uris = [`greynoise://ip/${ip}`, "greynoise://cve/CVE-2021-44228", ...(tagSlug ? [`greynoise://tag/${tagSlug}`] : []), ...resources.map((r) => r.uri)];
+    for (const uri of uris) {
+      try { const r = await client.readResource({ uri }); record(r.contents?.length ? "PASS" : "WARN", "res:" + uri); }
+      catch (e) { const m = String(e?.message); record(isGated(m) ? "GATED" : "FAIL", "res:" + uri, m.slice(0, 120)); }
+    }
+
+    console.log("── Write tools (round-trip) ──");
+    if (!writeWorkspace) {
+      for (const n of writeTools) record("SKIPPED", n, "set GN_WORKSPACE to a disposable workspace to round-trip writes");
+    } else {
+      await writeRoundTrip(client, writeWorkspace);
+    }
+  } finally {
+    await cleanup(client).catch((e) => console.error("cleanup error:", e));
+    await client.close().catch(() => {});
+  }
   report();
+}
+
+async function createTracked(client, name, args, type, workspace_id) {
+  const r = await callTool(client, name, args);
+  const id = r && !r.isError ? r.structuredContent?.id : undefined;
+  if (id) created.push({ type, workspace_id, id });
+  return id;
 }
 
 async function writeRoundTrip(client, workspace_id) {
   // Blocklist lifecycle
-  let blId;
-  try {
-    const r = await client.callTool({ name: "create-blocklist", arguments: { workspace_id, query: "classification:malicious", name: "mcp-validate-DELETE-ME", ip_limit: 10 } });
-    const text = r.content?.find((x) => x.type === "text")?.text ?? "";
-    if (r.isError) { isGated(text) ? record("GATED", "create-blocklist") : record("FAIL", "create-blocklist", text.slice(0, 120)); }
-    else { blId = r.structuredContent?.id; record("PASS", "create-blocklist", "+structured"); }
-  } catch (e) { record("FAIL", "create-blocklist", String(e?.message).slice(0, 120)); }
+  const blId = await createTracked(client, "create-blocklist",
+    { workspace_id, query: "classification:malicious", name: "mcp-validate-DELETE-ME", ip_limit: 10 }, "blocklist", workspace_id);
   if (blId) {
     await callTool(client, "get-blocklist", { workspace_id, blocklist_id: blId });
     await callTool(client, "get-blocklist-ips", { workspace_id, blocklist_id: blId });
     await callTool(client, "update-blocklist", { workspace_id, blocklist_id: blId, query: "classification:malicious", enabled: false });
-    await callTool(client, "delete-blocklist", { workspace_id, blocklist_id: blId });
+    const r = await callTool(client, "delete-blocklist", { workspace_id, blocklist_id: blId });
+    if (r && !r.isError) untrack(blId);
   }
-  await callTool(client, "list-blocklists", { workspace_id });
 
   // Alert lifecycle
-  let alId;
-  try {
-    const r = await client.callTool({ name: "create-alert", arguments: { workspace_id, name: "mcp-validate-DELETE-ME", query: "classification:malicious", schedule: { type: "daily", time_of_day: "09:00" }, recipients: [{ type: "email", value: "noreply@greynoise.io" }] } });
-    const text = r.content?.find((x) => x.type === "text")?.text ?? "";
-    if (r.isError) { isGated(text) ? record("GATED", "create-alert") : record("FAIL", "create-alert", text.slice(0, 120)); }
-    else { alId = r.structuredContent?.id; record("PASS", "create-alert", "+structured"); }
-  } catch (e) { record("FAIL", "create-alert", String(e?.message).slice(0, 120)); }
+  const alId = await createTracked(client, "create-alert",
+    { workspace_id, name: "mcp-validate-DELETE-ME", query: "classification:malicious", schedule: { type: "daily", time_of_day: "09:00" }, recipients: [{ type: "email", value: "noreply@greynoise.io" }] }, "alert", workspace_id);
   if (alId) {
     await callTool(client, "get-alert", { workspace_id, alert_id: alId });
     await callTool(client, "disable-alert", { workspace_id, alert_id: alId });
     await callTool(client, "enable-alert", { workspace_id, alert_id: alId });
-    await callTool(client, "delete-alert", { workspace_id, alert_id: alId });
+    await callTool(client, "update-alert", { workspace_id, alert_id: alId, name: "mcp-validate-DELETE-ME", query: "classification:malicious", schedule: { type: "daily", time_of_day: "10:00" }, recipients: [{ type: "email", value: "noreply@greynoise.io" }] });
+    const r = await callTool(client, "delete-alert", { workspace_id, alert_id: alId });
+    if (r && !r.isError) untrack(alId);
   }
-  await callTool(client, "list-alerts", { workspace_id });
   await callTool(client, "test-alert-webhook", { workspace_id, url: "https://example.com/greynoise-mcp-validate" });
 }
 
 function report() {
-  const by = (k) => results.filter((r) => r.kind === k);
   const order = ["FAIL", "WARN", "GATED", "SKIPPED", "PASS"];
   console.log("\n──────── RESULTS ────────");
   for (const r of results.sort((a, b) => order.indexOf(a.kind) - order.indexOf(b.kind))) {
     const icon = { PASS: "✅", GATED: "🔒", WARN: "⚠️ ", SKIPPED: "⏭️ ", FAIL: "❌" }[r.kind];
     console.log(`${icon} ${r.name}${r.detail ? " — " + r.detail : ""}`);
   }
-  const c = Object.fromEntries(order.map((k) => [k, by(k).length]));
+  const c = Object.fromEntries(order.map((k) => [k, results.filter((r) => r.kind === k).length]));
   console.log(`\nSUMMARY: ${c.PASS} pass · ${c.GATED} gated · ${c.WARN} warn · ${c.SKIPPED} skipped · ${c.FAIL} fail`);
   if (c.FAIL > 0) { console.error("\n❌ VALIDATION FAILED — do not promote."); process.exit(1); }
   console.log("\n✅ No hard failures. Review warnings before promoting.");
 }
 
-main().catch((e) => { console.error("harness error:", e); process.exit(1); });
+main().catch((e) => { console.error("harness error:", e); process.exitCode = 1; });

--- a/src/greynoise/client.ts
+++ b/src/greynoise/client.ts
@@ -15,6 +15,8 @@ const USER_AGENT = `${PACKAGE_NAME}/${typeof __PKG_VERSION__ !== "undefined" ? _
 const DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_RETRIES = 3;
 
+const accountSchema = z.object({ workspace_id: z.string() }).passthrough();
+
 interface RequestOptions {
   method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
   params?: Record<string, unknown>;
@@ -29,9 +31,20 @@ export class GreyNoiseClient {
     private readonly apiKeyGetter: () => string,
   ) {}
 
+  private cachedWorkspaceId?: string;
+
   /** Stable, non-reversible identity for the current API key — safe to use as a cache key. */
   cacheKey(): string {
     return createHash("sha256").update(`${this.apiBase}\0${this.apiKeyGetter()}`).digest("hex");
+  }
+
+  /** The workspace the API key is bound to (from /v1/account), resolved once and cached. */
+  async workspaceId(): Promise<string> {
+    if (!this.cachedWorkspaceId) {
+      const account = await this.get("v1/account", accountSchema);
+      this.cachedWorkspaceId = account.workspace_id;
+    }
+    return this.cachedWorkspaceId;
   }
 
   private buildUrl(endpoint: string, params?: Record<string, unknown>): URL {

--- a/src/greynoise/client.ts
+++ b/src/greynoise/client.ts
@@ -122,12 +122,12 @@ export class GreyNoiseClient {
     return Number.isNaN(dateMs) ? 0 : Math.max(0, dateMs - Date.now());
   }
 
-  get<T>(endpoint: string, schema: z.ZodType<T>, params?: Record<string, unknown>): Promise<T> {
-    return this.send(endpoint, schema, { method: "GET", params });
+  get<T>(endpoint: string, schema: z.ZodType<T>, params?: Record<string, unknown>, timeoutMs?: number): Promise<T> {
+    return this.send(endpoint, schema, { method: "GET", params, timeoutMs });
   }
 
-  post<T>(endpoint: string, schema: z.ZodType<T>, body?: unknown): Promise<T> {
-    return this.send(endpoint, schema, { method: "POST", body });
+  post<T>(endpoint: string, schema: z.ZodType<T>, body?: unknown, timeoutMs?: number): Promise<T> {
+    return this.send(endpoint, schema, { method: "POST", body, timeoutMs });
   }
 
   put<T>(endpoint: string, schema: z.ZodType<T>, body: unknown): Promise<T> {

--- a/src/greynoise/schemas/gnql.ts
+++ b/src/greynoise/schemas/gnql.ts
@@ -70,6 +70,8 @@ const gnqlTimeseriesRecordSchema = passthrough({
 });
 
 export const gnqlTimeseriesSchema = z.record(z.string(), z.array(gnqlTimeseriesRecordSchema));
+// Object wrapper for the tool outputSchema — the SDK can't derive a JSON Schema from a top-level z.record.
+export const gnqlTimeseriesResultSchema = passthrough({ buckets: gnqlTimeseriesSchema });
 
 export const gnqlTimeseriesStatsSchema = passthrough({
   count: z.number(),

--- a/src/greynoise/schemas/operational.ts
+++ b/src/greynoise/schemas/operational.ts
@@ -42,9 +42,9 @@ export const alertSchema = passthrough({
   enabled: z.boolean().optional(),
   status: z.string().optional(),
   gnql_query: z.string().optional(),
-  parameters: z.array(alertParameterSchema).optional(),
-  schedule: alertScheduleSchema.optional(),
-  recipients: z.array(alertRecipientSchema).optional(),
+  parameters: z.array(alertParameterSchema).nullish(),
+  schedule: alertScheduleSchema.nullish(),
+  recipients: z.array(alertRecipientSchema).nullish(),
   created_at: z.string().optional(),
   updated_at: z.string().optional(),
 });

--- a/src/greynoise/schemas/sessions-search.ts
+++ b/src/greynoise/schemas/sessions-search.ts
@@ -100,9 +100,10 @@ export const sessionUniqueValuesSchema = passthrough({
 });
 
 export const sessionExportFileSchema = passthrough({
-  filePath: z.string(),
-  fileSize: z.number(),
-  type: z.string(),
+  available: z.boolean().optional(),
+  filePath: z.string().optional(),
+  fileSize: z.number().optional(),
+  type: z.string().optional(),
 });
 
 export type SessionsResponse = z.infer<typeof sessionsResponseSchema>;

--- a/src/tools/alerts.ts
+++ b/src/tools/alerts.ts
@@ -11,7 +11,7 @@ import {
   deletionResultSchema,
 } from "../greynoise/schemas/operational.js";
 
-const wid = z.string().describe("Workspace ID (UUID) that owns the alert");
+const wid = z.string().optional().describe("Workspace ID (UUID). Defaults to the workspace the API key is bound to.");
 const aid = z.string().describe("Alert ID (UUID)");
 const v2 = (id: string) => `v2/workspaces/${encodeURIComponent(id)}/alerts`;
 
@@ -80,8 +80,9 @@ export function registerAlertTools(server: McpServer, apiBase: string, apiKeyGet
     outputSchema: alertSchema,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
     handler: async ({ workspace_id, name, query, schedule, recipients, enabled, query_workspace_id }, { client }) => {
+      const ws = workspace_id ?? (await client.workspaceId());
       const data = await client.post(
-        v2(workspace_id),
+        v2(ws),
         alertSchema,
         buildBody(query, name, schedule, recipients, enabled, query_workspace_id),
       );
@@ -96,7 +97,8 @@ export function registerAlertTools(server: McpServer, apiBase: string, apiKeyGet
     inputSchema: { workspace_id: wid },
     outputSchema: alertsWrapperSchema,
     handler: async ({ workspace_id }, { client }) => {
-      const alerts = await client.get(v2(workspace_id), alertListSchema);
+      const ws = workspace_id ?? (await client.workspaceId());
+      const alerts = await client.get(v2(ws), alertListSchema);
       return { text: `${alerts.length} alert(s) configured.`, structured: { alerts } };
     },
   });
@@ -108,7 +110,8 @@ export function registerAlertTools(server: McpServer, apiBase: string, apiKeyGet
     inputSchema: { workspace_id: wid, alert_id: aid },
     outputSchema: alertSchema,
     handler: async ({ workspace_id, alert_id }, { client }) => {
-      const data = await client.get(`${v2(workspace_id)}/${encodeURIComponent(alert_id)}`, alertSchema);
+      const ws = workspace_id ?? (await client.workspaceId());
+      const data = await client.get(`${v2(ws)}/${encodeURIComponent(alert_id)}`, alertSchema);
       return { text: `Alert "${data.name ?? data.id}" — enabled: ${data.enabled ?? "?"}.`, structured: data };
     },
   });
@@ -130,8 +133,9 @@ export function registerAlertTools(server: McpServer, apiBase: string, apiKeyGet
     outputSchema: alertSchema,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
     handler: async ({ workspace_id, alert_id, name, query, schedule, recipients, enabled, query_workspace_id }, { client }) => {
+      const ws = workspace_id ?? (await client.workspaceId());
       const data = await client.put(
-        `${v2(workspace_id)}/${encodeURIComponent(alert_id)}`,
+        `${v2(ws)}/${encodeURIComponent(alert_id)}`,
         alertSchema,
         buildBody(query, name, schedule, recipients, enabled, query_workspace_id),
       );
@@ -147,7 +151,8 @@ export function registerAlertTools(server: McpServer, apiBase: string, apiKeyGet
     outputSchema: deletionResultSchema,
     annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true },
     handler: async ({ workspace_id, alert_id }, { client }) => {
-      await client.del(`${v2(workspace_id)}/${encodeURIComponent(alert_id)}`, okSchema);
+      const ws = workspace_id ?? (await client.workspaceId());
+      await client.del(`${v2(ws)}/${encodeURIComponent(alert_id)}`, okSchema);
       return { text: `Deleted alert ${alert_id}.`, structured: { id: alert_id, deleted: true } };
     },
   });
@@ -160,7 +165,8 @@ export function registerAlertTools(server: McpServer, apiBase: string, apiKeyGet
     outputSchema: alertSchema,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
     handler: async ({ workspace_id, alert_id }, { client }) => {
-      const data = await setAlertEnabled(client, workspace_id, alert_id, true);
+      const ws = workspace_id ?? (await client.workspaceId());
+      const data = await setAlertEnabled(client, ws, alert_id, true);
       return { text: `Enabled alert ${alert_id}.`, structured: data };
     },
   });
@@ -173,7 +179,8 @@ export function registerAlertTools(server: McpServer, apiBase: string, apiKeyGet
     outputSchema: alertSchema,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
     handler: async ({ workspace_id, alert_id }, { client }) => {
-      const data = await setAlertEnabled(client, workspace_id, alert_id, false);
+      const ws = workspace_id ?? (await client.workspaceId());
+      const data = await setAlertEnabled(client, ws, alert_id, false);
       return { text: `Disabled alert ${alert_id}.`, structured: data };
     },
   });
@@ -191,7 +198,8 @@ export function registerAlertTools(server: McpServer, apiBase: string, apiKeyGet
     outputSchema: testWebhookResponseSchema,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
     handler: async ({ workspace_id, url, headers, type }, { client }) => {
-      const data = await client.post(`${v2(workspace_id)}/test-webhook`, testWebhookResponseSchema, {
+      const ws = workspace_id ?? (await client.workspaceId());
+      const data = await client.post(`${v2(ws)}/test-webhook`, testWebhookResponseSchema, {
         url,
         headers,
         type,

--- a/src/tools/alerts.ts
+++ b/src/tools/alerts.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { GreyNoiseClient } from "../greynoise/client.js";
 import { defineTool } from "./define-tool.js";
 import {
   alertSchema,
@@ -13,7 +14,22 @@ import {
 const wid = z.string().describe("Workspace ID (UUID) that owns the alert");
 const aid = z.string().describe("Alert ID (UUID)");
 const v2 = (id: string) => `v2/workspaces/${encodeURIComponent(id)}/alerts`;
-const v1 = (id: string) => `v1/workspaces/${encodeURIComponent(id)}/alerts`;
+
+// v2 alerts have no dedicated enable/disable endpoint — toggle via a full update
+// (a partial update would clobber the alert's other fields).
+async function setAlertEnabled(client: GreyNoiseClient, workspace_id: string, alert_id: string, enabled: boolean) {
+  const path = `${v2(workspace_id)}/${encodeURIComponent(alert_id)}`;
+  const a = await client.get(path, alertSchema);
+  const body = {
+    name: a.name ?? "",
+    enabled,
+    query_workspace_id: a.query_workspace_id,
+    parameters: [{ type: "query", value: a.gnql_query ?? "" }],
+    schedule: a.schedule ?? { type: "daily" },
+    recipients: (a.recipients ?? []).map((r) => ({ type: r.type, value: r.value })),
+  };
+  return client.put(path, alertSchema, body);
+}
 
 const recipientsSchema = z
   .array(
@@ -141,10 +157,10 @@ export function registerAlertTools(server: McpServer, apiBase: string, apiKeyGet
     title: "Enable Alert",
     description: "Enable (resume) a previously disabled alert.",
     inputSchema: { workspace_id: wid, alert_id: aid },
-    outputSchema: okSchema,
+    outputSchema: alertSchema,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
     handler: async ({ workspace_id, alert_id }, { client }) => {
-      const data = await client.post(`${v1(workspace_id)}/${encodeURIComponent(alert_id)}/enable`, okSchema);
+      const data = await setAlertEnabled(client, workspace_id, alert_id, true);
       return { text: `Enabled alert ${alert_id}.`, structured: data };
     },
   });
@@ -154,10 +170,10 @@ export function registerAlertTools(server: McpServer, apiBase: string, apiKeyGet
     title: "Disable Alert",
     description: "Disable (pause) an alert without deleting it.",
     inputSchema: { workspace_id: wid, alert_id: aid },
-    outputSchema: okSchema,
+    outputSchema: alertSchema,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
     handler: async ({ workspace_id, alert_id }, { client }) => {
-      const data = await client.post(`${v1(workspace_id)}/${encodeURIComponent(alert_id)}/disable`, okSchema);
+      const data = await setAlertEnabled(client, workspace_id, alert_id, false);
       return { text: `Disabled alert ${alert_id}.`, structured: data };
     },
   });

--- a/src/tools/blocklists.ts
+++ b/src/tools/blocklists.ts
@@ -9,7 +9,7 @@ import {
   deletionResultSchema,
 } from "../greynoise/schemas/operational.js";
 
-const wid = z.string().describe("Workspace ID (UUID) that owns the blocklist");
+const wid = z.string().optional().describe("Workspace ID (UUID). Defaults to the workspace the API key is bound to.");
 const bid = z.string().describe("Blocklist ID (UUID)");
 const bl = (id: string) => `v3/workspaces/${encodeURIComponent(id)}/blocklists`;
 
@@ -29,7 +29,8 @@ export function registerBlocklistTools(server: McpServer, apiBase: string, apiKe
     outputSchema: blocklistSchema,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
     handler: async ({ workspace_id, query, name, ip_limit, enabled }, { client }) => {
-      const data = await client.post(bl(workspace_id), blocklistSchema, { query, name, ip_limit, enabled });
+      const ws = workspace_id ?? (await client.workspaceId());
+      const data = await client.post(bl(ws), blocklistSchema, { query, name, ip_limit, enabled });
       return { text: `Created blocklist "${data.name ?? data.id}" (id: ${data.id}).`, structured: data };
     },
   });
@@ -45,7 +46,8 @@ export function registerBlocklistTools(server: McpServer, apiBase: string, apiKe
     },
     outputSchema: listBlocklistsSchema,
     handler: async ({ workspace_id, limit, offset }, { client }) => {
-      const data = await client.get(bl(workspace_id), listBlocklistsSchema, { limit, offset });
+      const ws = workspace_id ?? (await client.workspaceId());
+      const data = await client.get(bl(ws), listBlocklistsSchema, { limit, offset });
       return { text: `${data.blocklists.length} blocklist(s) returned.`, structured: data };
     },
   });
@@ -57,7 +59,8 @@ export function registerBlocklistTools(server: McpServer, apiBase: string, apiKe
     inputSchema: { workspace_id: wid, blocklist_id: bid },
     outputSchema: blocklistSchema,
     handler: async ({ workspace_id, blocklist_id }, { client }) => {
-      const data = await client.get(`${bl(workspace_id)}/${encodeURIComponent(blocklist_id)}`, blocklistSchema);
+      const ws = workspace_id ?? (await client.workspaceId());
+      const data = await client.get(`${bl(ws)}/${encodeURIComponent(blocklist_id)}`, blocklistSchema);
       return { text: `Blocklist "${data.name ?? data.id}" — ${data.last_ip_count ?? 0} IPs.`, structured: data };
     },
   });
@@ -77,7 +80,8 @@ export function registerBlocklistTools(server: McpServer, apiBase: string, apiKe
     outputSchema: blocklistSchema,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
     handler: async ({ workspace_id, blocklist_id, query, name, ip_limit, enabled }, { client }) => {
-      const data = await client.put(`${bl(workspace_id)}/${encodeURIComponent(blocklist_id)}`, blocklistSchema, {
+      const ws = workspace_id ?? (await client.workspaceId());
+      const data = await client.put(`${bl(ws)}/${encodeURIComponent(blocklist_id)}`, blocklistSchema, {
         query,
         name,
         ip_limit,
@@ -95,7 +99,8 @@ export function registerBlocklistTools(server: McpServer, apiBase: string, apiKe
     outputSchema: deletionResultSchema,
     annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true },
     handler: async ({ workspace_id, blocklist_id }, { client }) => {
-      await client.del(`${bl(workspace_id)}/${encodeURIComponent(blocklist_id)}`, okSchema);
+      const ws = workspace_id ?? (await client.workspaceId());
+      await client.del(`${bl(ws)}/${encodeURIComponent(blocklist_id)}`, okSchema);
       return { text: `Deleted blocklist ${blocklist_id}.`, structured: { id: blocklist_id, deleted: true } };
     },
   });
@@ -111,11 +116,8 @@ export function registerBlocklistTools(server: McpServer, apiBase: string, apiKe
     },
     outputSchema: blocklistIpsSchema,
     handler: async ({ workspace_id, blocklist_id, size }, { client }) => {
-      const data = await client.get(
-        `${bl(workspace_id)}/${encodeURIComponent(blocklist_id)}/ips`,
-        blocklistIpsSchema,
-        { size },
-      );
+      const ws = workspace_id ?? (await client.workspaceId());
+      const data = await client.get(`${bl(ws)}/${encodeURIComponent(blocklist_id)}/ips`, blocklistIpsSchema, { size });
       return { text: `${data.ips.length} IP(s) in blocklist ${blocklist_id}.`, structured: data };
     },
   });

--- a/src/tools/callback.ts
+++ b/src/tools/callback.ts
@@ -78,11 +78,23 @@ export function registerCallbackTools(server: McpServer, apiBase: string, apiKey
     name: "callback-overview",
     title: "Callback Overview Statistics",
     description:
-      "Aggregate statistics for callback/C2 IPs matching the filters: counts by attack stage, file analysis status, RIOT trust levels, scanner associations, and top threat names. Dates are YYYY-MM-DD.",
-    inputSchema: { ...filterFields },
+      "Aggregate statistics for callback/C2 IPs matching the filters: counts by attack stage, file analysis status, RIOT trust levels, scanner associations, and top threat names. Bounded to a recent window (days: 1-7, default 1) — wider ranges overload the aggregation.",
+    inputSchema: {
+      days: z.number().int().min(1).max(7).default(1).describe("Lookback window in days (1-7, default 1)"),
+      is_stage_1: filterFields.is_stage_1,
+      is_stage_2: filterFields.is_stage_2,
+      has_files: filterFields.has_files,
+      file_type: filterFields.file_type,
+      file_name: filterFields.file_name,
+      file_hash: filterFields.file_hash,
+      scanner_ips: filterFields.scanner_ips,
+      ips: filterFields.ips,
+    },
     outputSchema: callbackOverviewSchema,
-    handler: async (args, { client }) => {
-      const data = await client.post("v1/callback/overview", callbackOverviewSchema, args);
+    handler: async ({ days, ...filters }, { client }) => {
+      const firstSeenAfter = new Date(Date.now() - days * 864e5).toISOString().slice(0, 10);
+      const body = { ...filters, first_seen_after: firstSeenAfter };
+      const data = await client.post("v1/callback/overview", callbackOverviewSchema, body, 60_000);
       return { text: formatCallbackOverview(data), structured: data };
     },
   });

--- a/src/tools/export-sessions-pcap.ts
+++ b/src/tools/export-sessions-pcap.ts
@@ -6,6 +6,7 @@ import { join } from "path";
 import { unlink } from "fs/promises";
 import { defineTool } from "./define-tool.js";
 import { pcapFileSchema } from "../greynoise/schemas/sessions.js";
+import { GreyNoiseApiError } from "../greynoise/errors.js";
 
 const PCAP_HEADER_SIZE = 24;
 
@@ -41,7 +42,15 @@ Use Lucene query syntax to filter sessions (e.g., "destination.port:443", "sourc
       if (scope) params.scope = scope;
 
       await log("info", `Exporting session PCAP for ${start_time}..${end_time}...`);
-      const { filePath, fileSize } = await client.getBinary(`v3/sessions/export`, outputPath, params);
+      let filePath: string, fileSize: number;
+      try {
+        ({ filePath, fileSize } = await client.getBinary(`v3/sessions/export`, outputPath, params));
+      } catch (e) {
+        if (e instanceof GreyNoiseApiError && e.status === 404) {
+          return { text: `No matching sessions found for the given query and time range.`, structured: { available: false } };
+        }
+        throw e;
+      }
 
       if (fileSize <= PCAP_HEADER_SIZE) {
         await unlink(filePath).catch(() => {});

--- a/src/tools/get-session-pcap.ts
+++ b/src/tools/get-session-pcap.ts
@@ -6,6 +6,7 @@ import { join } from "path";
 import { unlink } from "fs/promises";
 import { defineTool } from "./define-tool.js";
 import { pcapFileSchema } from "../greynoise/schemas/sessions.js";
+import { GreyNoiseApiError } from "../greynoise/errors.js";
 
 const PCAP_HEADER_SIZE = 24;
 
@@ -27,11 +28,19 @@ export function registerGetSessionPcapTool(server: McpServer, apiBase: string, a
       if (scope) params.scope = scope;
 
       await log("info", `Downloading PCAP for session ${session_id}...`);
-      const { filePath, fileSize } = await client.getBinary(
-        `v3/sessions/${encodeURIComponent(session_id)}/frames`,
-        outputPath,
-        params,
-      );
+      let filePath: string, fileSize: number;
+      try {
+        ({ filePath, fileSize } = await client.getBinary(
+          `v3/sessions/${encodeURIComponent(session_id)}/frames`,
+          outputPath,
+          params,
+        ));
+      } catch (e) {
+        if (e instanceof GreyNoiseApiError && e.status === 404) {
+          return { text: `Session ${session_id} not found or has no captured frames.`, structured: { available: false } };
+        }
+        throw e;
+      }
 
       if (fileSize <= PCAP_HEADER_SIZE) {
         await unlink(filePath).catch(() => {});

--- a/src/tools/gnql-timeseries.ts
+++ b/src/tools/gnql-timeseries.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { defineTool } from "./define-tool.js";
-import { gnqlTimeseriesSchema } from "../greynoise/schemas/gnql.js";
+import { gnqlTimeseriesSchema, gnqlTimeseriesResultSchema } from "../greynoise/schemas/gnql.js";
 import { formatGnqlTimeseries } from "../utils/formatters/gnql.js";
 
 export function registerGnqlTimeseriesTool(server: McpServer, apiBase: string, apiKeyGetter: () => string) {
@@ -19,13 +19,13 @@ Time bounds use ISO 8601 (e.g. 2025-01-15T00:00:00Z). size is results per hourly
       end_time: z.string().optional().describe("End of time range (ISO 8601 format)"),
       size: z.number().min(1).max(10000).default(25).optional().describe("Results per hourly bucket (default: 25)"),
     },
-    outputSchema: gnqlTimeseriesSchema,
+    outputSchema: gnqlTimeseriesResultSchema,
     handler: async ({ query, start_time, end_time, size }, { client }) => {
       const params: Record<string, unknown> = { query, size: size ?? 25 };
       if (start_time) params.start = start_time;
       if (end_time) params.end = end_time;
       const data = await client.get("v3/gnql/timeseries", gnqlTimeseriesSchema, params);
-      return { text: formatGnqlTimeseries(data), structured: data };
+      return { text: formatGnqlTimeseries(data), structured: { buckets: data } };
     },
   });
 }

--- a/src/tools/sessions-search.ts
+++ b/src/tools/sessions-search.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "crypto";
 import { tmpdir } from "os";
 import { join } from "path";
 import { defineTool } from "./define-tool.js";
+import { GreyNoiseApiError } from "../greynoise/errors.js";
 import {
   sessionsResponseSchema,
   sessionFieldsResponseSchema,
@@ -272,13 +273,21 @@ export function registerSessionSearchTools(server: McpServer, apiBase: string, a
       const ext = fmt === "pcap" ? "pcap" : "bin";
       const outputPath = join(tmpdir(), `greynoise-session-${randomUUID()}.${ext}`);
       await log("info", `Exporting session ${session_id} as ${fmt}...`);
-      const { filePath, fileSize } = await client.getBinary(
-        `v3/sessions/${encodeURIComponent(session_id)}/export`,
-        outputPath,
-        { type, scope },
-        fmt === "pcap" ? "application/vnd.tcpdump.pcap" : "application/octet-stream",
-      );
-      const structured = { filePath, fileSize, type: fmt };
+      let filePath: string, fileSize: number;
+      try {
+        ({ filePath, fileSize } = await client.getBinary(
+          `v3/sessions/${encodeURIComponent(session_id)}/export`,
+          outputPath,
+          { type, scope },
+          fmt === "pcap" ? "application/vnd.tcpdump.pcap" : "application/octet-stream",
+        ));
+      } catch (e) {
+        if (e instanceof GreyNoiseApiError && e.status === 404) {
+          return { text: `No exportable data for session ${session_id}.`, structured: { available: false } };
+        }
+        throw e;
+      }
+      const structured = { available: true, filePath, fileSize, type: fmt };
       let text = `# Session Data Export\n\n`;
       text += `**Session**: ${session_id}\n**Type**: ${fmt}\n**File**: ${filePath}\n**Size**: ${fileSize.toLocaleString()} bytes\n`;
       return { text, structured };


### PR DESCRIPTION
<img width="894" height="357" alt="image" src="https://github.com/user-attachments/assets/997979b1-7f79-4997-acb9-940980290074" />

<img width="760" height="1171" alt="image" src="https://github.com/user-attachments/assets/5920015b-eb4e-4814-ba1d-43314289eec2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **New Features**
  - Updated `callback-overview` to use a `days` lookback window (1–7) instead of explicit date ranges.
  - Alert enable/disable tools now return the updated alert configuration.
- **Bug Fixes**
  - Fixed `gnql-timeseries` structured output to return `buckets` in the expected shape.
  - Improved “not found” handling for session/PCAP and exported-session tools (`available: false`).
- **Tests**
  - Added CI live validation via `npm run validate`, running in read-only mode when configured and safely skipping when credentials are unavailable.
  - Alert/blocklist tools now better handle omitted `workspace_id` by using the API key’s default workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->