### PR TITLE
Automate versions on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,14 +26,13 @@ jobs:
 
       - run: npm ci
 
-      - name: Verify tag matches package.json version
+      # The git tag is the single source of truth for the version. Stamp it into
+      # package.json (+ package-lock) and sync manifest.json — no manual bump needed.
+      - name: Set version from tag
         run: |
-          TAG="${GITHUB_REF_NAME#v}"
-          PKG="$(node -p "require('./package.json').version")"
-          if [ "$TAG" != "$PKG" ]; then
-            echo "tag $TAG does not match package.json $PKG"
-            exit 1
-          fi
+          VERSION="${GITHUB_REF_NAME#v}"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version --ignore-scripts
+          node scripts/sync-version.mjs
 
       - run: npm test
       - run: npm run build

--- a/README.md
+++ b/README.md
@@ -205,14 +205,13 @@ Releases are automated via GitHub Actions, with a manual approval gate. Two work
 
 ### Cutting a release
 
-1. Merge your work to `main`.
-2. Bump the version (`package.json` is the single source of truth; the `version` script keeps `manifest.json` in sync, and the User-Agent is injected from it at build time):
-   ```bash
-   npm version minor        # or patch / major — creates the commit + vX.Y.Z tag
-   git push --follow-tags
-   ```
-   The tag must match `package.json`, or the workflow fails.
-3. The tag triggers `release.yml`, which **stages** the version to npm and creates a **draft** GitHub Release. Neither is public yet.
+Push a version tag — that's the whole release. The **git tag is the single source of truth**: the workflow stamps it into `package.json` + `manifest.json` (and the User-Agent) at build time, so there's nothing to bump or keep in sync by hand.
+
+```bash
+git tag v0.5.1 && git push origin v0.5.1
+```
+
+The tag triggers `release.yml`, which **stages** that version to npm and creates a **draft** GitHub Release. Neither is public yet.
 
 ### Approving (the manual gate)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Release builds now derive the package version directly from the Git tag.
  * Version information is automatically applied to package metadata and manifests during release builds.
  * Simplified release instructions to use version tags as the single source of truth.

* **Documentation**
  * Updated release guidance to reflect the streamlined tagging workflow.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->