### PR TITLE
Better handling for 403 entitlement errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # GreyNoise MCP Server
 
-A [Model Context Protocol](https://modelcontextprotocol.io) server for the GreyNoise Enterprise API. It gives MCP-compatible clients (Claude Desktop, Claude Code, Cursor, etc.) access to GreyNoise threat intelligence — IP context, GNQL search, Recall timeseries, tags, CVEs, sensor sessions, BSI, callback/C2 data — plus operational tools to act on findings (blocklists and alerts).
+A [Model Context Protocol](https://modelcontextprotocol.io) server for the GreyNoise API. It gives MCP-compatible clients (Claude Desktop, Claude Code, Cursor, etc.) access to GreyNoise threat intelligence — IP context, GNQL search, Recall timeseries, tags, CVEs, sensor sessions, BSI, callback/C2 data — plus operational tools to act on findings (blocklists and alerts).
 
-**Requires a GreyNoise Enterprise API key.** Some capabilities (BSI, callback, blocklists, alerts) require additional plan entitlements; the server exposes every tool and returns a clear "not entitled" message if your plan doesn't include one.
+**Requires a GreyNoise API key.** Your plan's entitlements determine which capabilities are available; the server exposes every tool and returns a clear "not entitled" message for any your plan doesn't include, so the rest keep working.
 
 ## Installation
 
@@ -42,7 +42,7 @@ Download `greynoise-mcp-server.mcpb` from the [releases page](https://github.com
 
 | Variable | Required | Default | Purpose |
 |---|---|---|---|
-| `GREYNOISE_API_KEY` | yes (stdio) | — | Enterprise API key. For HTTP transport the key is taken per-request from the `Authorization: Bearer` header instead. |
+| `GREYNOISE_API_KEY` | yes (stdio) | — | GreyNoise API key. For HTTP transport the key is taken per-request from the `Authorization: Bearer` header instead. |
 | `GREYNOISE_API_BASE` | no | `https://api.greynoise.io/` | Override the API base (e.g. staging). |
 | `PORT` | no | `9191` | HTTP transport listen port. |
 | `MCP_ALLOWED_HOSTS` | no | `127.0.0.1:<port>,localhost:<port>` | Allowed Host header values (DNS-rebinding protection) for HTTP transport. |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A [Model Context Protocol](https://modelcontextprotocol.io) server for the GreyNoise API. It gives MCP-compatible clients (Claude Desktop, Claude Code, Cursor, etc.) access to GreyNoise threat intelligence — IP context, GNQL search, Recall timeseries, tags, CVEs, sensor sessions, BSI, callback/C2 data — plus operational tools to act on findings (blocklists and alerts).
 
-**Requires a GreyNoise API key.** Your plan's entitlements determine which capabilities are available; the server exposes every tool and returns a clear "not entitled" message for any your plan doesn't include, so the rest keep working.
+**Requires a GreyNoise API key.** Your plan's entitlements determine which capabilities are available; the server exposes every tool and returns a clear "not entitled" message for any capability your plan doesn't include, so the rest keep working.
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2485,21 +2485,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -3385,9 +3398,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -6549,17 +6562,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {

--- a/src/greynoise/schemas/cve.ts
+++ b/src/greynoise/schemas/cve.ts
@@ -27,7 +27,7 @@ export const cveDetailsSchema = passthrough({
     number_of_available_exploits: z.number(),
     number_of_threat_actors_exploiting_vulnerability: z.number(),
     number_of_botnets_exploiting_vulnerability: z.number(),
-  }),
+  }).nullish(),
   exploitation_activity: passthrough({
     activity_seen: z.boolean(),
     benign_ip_count_1d: z.number(),
@@ -36,7 +36,7 @@ export const cveDetailsSchema = passthrough({
     threat_ip_count_1d: z.number(),
     threat_ip_count_10d: z.number(),
     threat_ip_count_30d: z.number(),
-  }),
+  }).nullish(),
 });
 
 export const trendingTagSchema = passthrough({

--- a/src/greynoise/schemas/gnql.ts
+++ b/src/greynoise/schemas/gnql.ts
@@ -29,10 +29,10 @@ export const gnqlIpItemSchema = passthrough({
   ip: z.string(),
   internet_scanner_intelligence: gnqlItemScannerSchema.optional(),
   business_service_intelligence: passthrough({
-    found: z.boolean().optional(),
-    name: z.string().optional(),
-    trust_level: z.string().optional(),
-  }).optional(),
+    found: z.boolean().nullish(),
+    name: z.string().nullish(),
+    trust_level: z.string().nullish(),
+  }).nullish(),
 });
 
 export const gnqlQuerySchema = passthrough({

--- a/src/tools/tool-errors.ts
+++ b/src/tools/tool-errors.ts
@@ -6,7 +6,7 @@ export function toUserMessage(error: unknown): string {
       case 401:
         return "Authentication failed (401): the GreyNoise API key is missing, invalid, or expired. Check the GREYNOISE_API_KEY.";
       case 403:
-        return "Not entitled (403): your GreyNoise plan does not include access to this capability. Contact your GreyNoise account team or sales@greynoise.io to enable it.";
+        return "Not entitled (403): this GreyNoise API key's plan does not include this capability. This is an access limitation, not evidence that the data is absent.";
       case 404:
         return `Not found (404): ${error.endpoint}.`;
       case 429:

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "@jest/globals";
+import type { CVEDetails } from "../greynoise/schemas/cve.js";
 import type { GnqlStats } from "../greynoise/schemas/gnql.js";
+import { formatCVEDetails } from "./formatters/cve.js";
 import { formatGnqlStats } from "./formatters/gnql.js";
 
 describe("formatGnqlStats", () => {
@@ -23,4 +25,44 @@ describe("formatGnqlStats", () => {
     expect(output).toContain("Adjusted Query: `(classification:malicious) last_seen:90d`");
     expect(output).toContain("- **Linux**: 10 IPs");
   });
+});
+
+describe("formatCVEDetails entitlement handling", () => {
+  const base: CVEDetails = {
+    id: "CVE-2024-3400",
+    details: {
+      vulnerability_name: "PAN-OS RCE",
+      vulnerability_description: "cmd injection",
+      cve_cvss_score: 10,
+      product: "PAN-OS",
+      vendor: "Palo Alto",
+      published_to_nist_nvd: true,
+    },
+    timeline: {
+      cve_published_date: "2024-04-12",
+      cve_last_updated_date: "2024-04-20",
+      first_known_published_date: "2024-04-12",
+    },
+    exploitation_details: { attack_vector: "NETWORK", exploit_found: true, exploitation_registered_in_kev: true, epss_score: 0.9 },
+    exploitation_stats: { number_of_available_exploits: 3, number_of_threat_actors_exploiting_vulnerability: 2, number_of_botnets_exploiting_vulnerability: 1 },
+    exploitation_activity: { activity_seen: true, benign_ip_count_1d: 1, benign_ip_count_10d: 2, benign_ip_count_30d: 3, threat_ip_count_1d: 4, threat_ip_count_10d: 5, threat_ip_count_30d: 6 },
+  };
+  const gated = "access limitation";
+
+  const cases: { name: string; data: CVEDetails; hasStats: boolean; hasActivity: boolean; noted: boolean }[] = [
+    { name: "fully entitled", data: base, hasStats: true, hasActivity: true, noted: false },
+    { name: "stats only", data: { ...base, exploitation_activity: undefined }, hasStats: true, hasActivity: false, noted: true },
+    { name: "activity only", data: { ...base, exploitation_stats: undefined }, hasStats: false, hasActivity: true, noted: true },
+    { name: "neither present", data: { ...base, exploitation_stats: undefined, exploitation_activity: undefined }, hasStats: false, hasActivity: false, noted: true },
+  ];
+
+  for (const c of cases) {
+    it(`${c.name}: renders present sections, flags gaps, never crashes`, () => {
+      const output = formatCVEDetails(c.data);
+      expect(output).toContain("## Exploitation Details");
+      expect(output.includes("## Exploitation Statistics\n")).toBe(c.hasStats);
+      expect(output.includes("**Activity Seen by GreyNoise**")).toBe(c.hasActivity);
+      expect(output.includes(gated)).toBe(c.noted);
+    });
+  }
 });

--- a/src/utils/formatters/cve.ts
+++ b/src/utils/formatters/cve.ts
@@ -38,13 +38,14 @@ export function formatCVEDetails(data: CVEDetails, tagActivityIPs = 0): string {
     response += `**Botnets Exploiting**: ${data.exploitation_stats.number_of_botnets_exploiting_vulnerability}\n\n`;
   }
 
-  response += `## Observed Activity\n\n`;
-  if (!data.exploitation_activity.activity_seen && tagActivityIPs > 0) {
-    response += `**Activity Seen by GreyNoise**: Yes — ${tagActivityIPs} IPs in the last 30d, from the associated tag timeline\n`;
-    response += `> The CVE record reports no activity, but the associated tag timeline shows ${tagActivityIPs} IPs. The CVE rollup lags backfilled tag hits; use get-tag-activity for exploitation timing.\n\n`;
-  } else {
-    response += `**Activity Seen by GreyNoise**: ${data.exploitation_activity.activity_seen ? "Yes" : "No"}\n\n`;
-  }
+  if (data.exploitation_activity) {
+    response += `## Observed Activity\n\n`;
+    if (!data.exploitation_activity.activity_seen && tagActivityIPs > 0) {
+      response += `**Activity Seen by GreyNoise**: Yes — ${tagActivityIPs} IPs in the last 30d, from the associated tag timeline\n`;
+      response += `> The CVE record reports no activity, but the associated tag timeline shows ${tagActivityIPs} IPs. The CVE rollup lags backfilled tag hits; use get-tag-activity for exploitation timing.\n\n`;
+    } else {
+      response += `**Activity Seen by GreyNoise**: ${data.exploitation_activity.activity_seen ? "Yes" : "No"}\n\n`;
+    }
 
     if (data.exploitation_activity.activity_seen) {
       response += `### Benign IP Counts\n`;

--- a/src/utils/formatters/cve.ts
+++ b/src/utils/formatters/cve.ts
@@ -60,9 +60,9 @@ export function formatCVEDetails(data: CVEDetails, tagActivityIPs = 0): string {
     }
   }
 
-  if (!data.exploitation_stats && !data.exploitation_activity) {
+  if (!data.exploitation_stats || !data.exploitation_activity) {
     response += `## Exploitation Statistics & Observed Activity\n\n`;
-    response += `Not included in this API key's plan. Their absence here is an access limitation, not evidence that no exploitation exists.\n`;
+    response += `Some of this data is not included in this API key's plan. Its absence is an access limitation, not evidence that no exploitation exists.\n`;
   }
 
   return response;

--- a/src/utils/formatters/cve.ts
+++ b/src/utils/formatters/cve.ts
@@ -31,24 +31,33 @@ export function formatCVEDetails(data: CVEDetails): string {
   response += `**In CISA Known Exploited Vulnerabilities Catalog**: ${data.exploitation_details.exploitation_registered_in_kev ? "Yes" : "No"}\n`;
   response += `**EPSS Score**: ${(data.exploitation_details.epss_score * 100).toFixed(2)}% (probability of exploitation)\n\n`;
 
-  response += `## Exploitation Statistics\n\n`;
-  response += `**Available Exploits**: ${data.exploitation_stats.number_of_available_exploits}\n`;
-  response += `**Threat Actors Exploiting**: ${data.exploitation_stats.number_of_threat_actors_exploiting_vulnerability}\n`;
-  response += `**Botnets Exploiting**: ${data.exploitation_stats.number_of_botnets_exploiting_vulnerability}\n\n`;
+  if (data.exploitation_stats) {
+    response += `## Exploitation Statistics\n\n`;
+    response += `**Available Exploits**: ${data.exploitation_stats.number_of_available_exploits}\n`;
+    response += `**Threat Actors Exploiting**: ${data.exploitation_stats.number_of_threat_actors_exploiting_vulnerability}\n`;
+    response += `**Botnets Exploiting**: ${data.exploitation_stats.number_of_botnets_exploiting_vulnerability}\n\n`;
+  }
 
-  response += `## Observed Activity\n\n`;
-  response += `**Activity Seen by GreyNoise**: ${data.exploitation_activity.activity_seen ? "Yes" : "No"}\n\n`;
+  if (data.exploitation_activity) {
+    response += `## Observed Activity\n\n`;
+    response += `**Activity Seen by GreyNoise**: ${data.exploitation_activity.activity_seen ? "Yes" : "No"}\n\n`;
 
-  if (data.exploitation_activity.activity_seen) {
-    response += `### Benign IP Counts\n`;
-    response += `- **Last 24 hours**: ${data.exploitation_activity.benign_ip_count_1d}\n`;
-    response += `- **Last 10 days**: ${data.exploitation_activity.benign_ip_count_10d}\n`;
-    response += `- **Last 30 days**: ${data.exploitation_activity.benign_ip_count_30d}\n\n`;
+    if (data.exploitation_activity.activity_seen) {
+      response += `### Benign IP Counts\n`;
+      response += `- **Last 24 hours**: ${data.exploitation_activity.benign_ip_count_1d}\n`;
+      response += `- **Last 10 days**: ${data.exploitation_activity.benign_ip_count_10d}\n`;
+      response += `- **Last 30 days**: ${data.exploitation_activity.benign_ip_count_30d}\n\n`;
 
-    response += `### Malicious IP Counts\n`;
-    response += `- **Last 24 hours**: ${data.exploitation_activity.threat_ip_count_1d}\n`;
-    response += `- **Last 10 days**: ${data.exploitation_activity.threat_ip_count_10d}\n`;
-    response += `- **Last 30 days**: ${data.exploitation_activity.threat_ip_count_30d}\n`;
+      response += `### Malicious IP Counts\n`;
+      response += `- **Last 24 hours**: ${data.exploitation_activity.threat_ip_count_1d}\n`;
+      response += `- **Last 10 days**: ${data.exploitation_activity.threat_ip_count_10d}\n`;
+      response += `- **Last 30 days**: ${data.exploitation_activity.threat_ip_count_30d}\n`;
+    }
+  }
+
+  if (!data.exploitation_stats && !data.exploitation_activity) {
+    response += `## Exploitation Statistics & Observed Activity\n\n`;
+    response += `Not included in this API key's plan. Their absence here is an access limitation, not evidence that no exploitation exists.\n`;
   }
 
   return response;

--- a/src/utils/formatters/gnql.ts
+++ b/src/utils/formatters/gnql.ts
@@ -26,7 +26,7 @@ export function formatGnqlMetadataCsv(data: GnqlQuery): string {
       isi?.metadata?.source_country ?? "",
       (isi?.tags ?? []).map((tag) => tag.name).join("; "),
       (isi?.raw_data?.scan ?? []).map((scan) => `${scan.port}/${scan.protocol}`).join("; "),
-      bsi?.found === undefined ? "" : bsi.found ? "true" : "false",
+      bsi?.found == null ? "" : bsi.found ? "true" : "false",
       bsi?.name ?? "",
       bsi?.trust_level ?? "",
     ];


### PR DESCRIPTION
## Why

Downstream consumers (e.g. Agent Smith) are opening up from Enterprise-only to any entitled paid tier. The server must degrade **per-tool** when a key can't reach a capability — return what's entitled, clearly flag what isn't, and never hard-fail or imply the data doesn't exist. Testing across several entitlement tiers surfaced two output-schema defects that crashed core tools for any non-BSI key.

## What changed

**403 message (`tool-errors.ts`)** — now neutral and factual: *"this GreyNoise API key's plan does not include this capability. This is an access limitation, not evidence that the data is absent."* Drops the sales CTA so it reads cleanly as a capability signal to both humans and agents.

**Schema null/absent tolerance (the actual bugs):**
- `gnql-query` — `business_service_intelligence.found` comes back `null` for non-BSI keys, but the schema required `boolean` (`.optional()` rejects `null`). Output validation threw → the **core query tool hard-crashed** for every non-BSI key. → `.nullish()`.
- `get-cve-details` — `exploitation_stats` / `exploitation_activity` are absent for lower tiers; the schema required them. → `.nullish()`.

**CVE formatter (`formatters/cve.ts`)** — guards the now-optional `exploitation_stats` / `exploitation_activity` sections (previously dereferenced blind → crash). When either is absent, emits a factual gated-note rather than silence: *"Some of this data is not included in this API key's plan. Its absence is an access limitation, not evidence that no exploitation exists."* Preserves the tag-timeline activity reconciliation.

**README** — de-Enterprise'd: *"Requires a GreyNoise API key"*; entitlements gate which tools are available, the rest keep working.

## Review feedback addressed (CodeRabbit)

- README entitlement sentence: added the missing noun ("for any **capability** your plan doesn't include").
- GNQL CSV formatter (`formatters/gnql.ts`): `bsi.found` unknown check now `== null` so a gated `null` renders as blank (unknown), not `"false"`.
- CVE formatter: the gated-note now fires when **either** section is missing (`||`), not only when both are — handles partial restriction. Added tests for full / stats-only / activity-only / neither-present.

## Testing

- `tsc --noEmit` clean; `jest` green (20 tests, +4 CVE-formatter entitlement cases).
- Verified against live keys across full / mid / core-only entitlement tiers: core tools return clean results for every tier; gated tools return the 403 signal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CVE details when exploitation data is unavailable or restricted, with clearer access-limitation messaging.
  * Prevented errors when optional exploitation information is missing.
  * Improved GNQL CSV exports by handling unavailable business intelligence values correctly.
  * Updated 403 error messaging to clarify plan-based API access restrictions.

* **Documentation**
  * Updated API key documentation to refer to the standard GreyNoise API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->